### PR TITLE
[#8, #3] JWT 기반 인증 기능 및 유저 Controller 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,12 +2,12 @@ import org.hidetake.gradle.swagger.generator.GenerateSwaggerUI
 import org.springframework.boot.gradle.tasks.bundling.BootJar
 
 plugins {
-	id 'java'
-	id 'org.springframework.boot' version '2.7.8'
-	id 'io.spring.dependency-management' version '1.0.15.RELEASE'
-	id 'org.asciidoctor.jvm.convert' version '3.3.2'
-	id 'org.hidetake.swagger.generator' version '2.18.2'
-	id 'com.epages.restdocs-api-spec' version '0.16.2'
+    id 'java'
+    id 'org.springframework.boot' version '2.7.8'
+    id 'io.spring.dependency-management' version '1.0.15.RELEASE'
+    id 'org.asciidoctor.jvm.convert' version '3.3.2'
+    id 'org.hidetake.swagger.generator' version '2.18.2'
+    id 'com.epages.restdocs-api-spec' version '0.16.2'
 }
 
 group = 'com.prgrms'
@@ -15,112 +15,114 @@ version = '1.0.0'
 sourceCompatibility = '17'
 
 configurations {
-	compileOnly {
-		extendsFrom annotationProcessor
-	}
+    compileOnly {
+        extendsFrom annotationProcessor
+    }
 }
 
 repositories {
-	mavenCentral()
+    mavenCentral()
 }
 
 ext {
-	set('snippetsDir', file("build/generated-snippets"))
+    set('snippetsDir', file("build/generated-snippets"))
 }
 
 swaggerSources {
-	sample {
-		setInputFile(file("${project.buildDir}/api-spec/openapi3.yaml"))
-	}
+    sample {
+        setInputFile(file("${project.buildDir}/api-spec/openapi3.yaml"))
+    }
 }
 
 openapi3 {
-	setServer("http://localhost:8080") // Swagger 서버 설정
-	title = "restdocs-swagger API Documentation"
-	description = "Spring REST Docs with SwaggerUI."
-	version = "1.0.0"
-	format = "yaml"
+    setServer("http://localhost:8080") // Swagger 서버 설정
+    title = "restdocs-swagger API Documentation"
+    description = "Spring REST Docs with SwaggerUI."
+    version = "1.0.0"
+    format = "yaml"
 }
 
 dependencies {
-	// Spring Boot Starter
-	// WEB
-	implementation 'org.springframework.boot:spring-boot-starter-web'
-	implementation 'org.springframework.boot:spring-boot-starter-validation'
-	// Security
-	implementation 'org.springframework.boot:spring-boot-starter-security'
-	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
-	testImplementation 'org.springframework.security:spring-security-test'
-	// DB
-	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	// Test & Config
-	implementation 'org.springframework.boot:spring-boot-starter-actuator'
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
-	annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'
+    // Spring Boot Starter
+    // WEB
+    implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
+    // Security
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+    implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+    testImplementation 'org.springframework.security:spring-security-test'
+    // DB
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    // Test & Config
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'
 
-	// Flyway
-	implementation 'org.flywaydb:flyway-core'
-	implementation 'org.flywaydb:flyway-mysql'
-	// Lombok
-	compileOnly 'org.projectlombok:lombok'
-	annotationProcessor 'org.projectlombok:lombok'
-	annotationProcessor "org.projectlombok:lombok-mapstruct-binding:0.2.0" // lombok 에서 mapstruct binding 해주는 기능
-	//MySQL Driver
-	runtimeOnly 'com.mysql:mysql-connector-j'
-	//H2 Driver
-	runtimeOnly 'com.h2database:h2'
-	// RestDocs API SPEC
-	testImplementation 'com.epages:restdocs-api-spec-mockmvc:0.16.2'
-	// Swagger UI
-	swaggerUI 'org.webjars:swagger-ui:4.11.1'
-	// JWT
-	implementation 'com.auth0:java-jwt:4.2.1'
-	// MapStruct
-	implementation 'org.mapstruct:mapstruct:1.5.3.Final'
-	annotationProcessor 'org.mapstruct:mapstruct-processor:1.5.3.Final'
-	// p6spy
-	implementation 'com.github.gavlyukovskiy:p6spy-spring-boot-starter:1.8.1'
+    // Flyway
+    implementation 'org.flywaydb:flyway-core'
+    implementation 'org.flywaydb:flyway-mysql'
+    // Lombok
+    compileOnly 'org.projectlombok:lombok'
+    annotationProcessor 'org.projectlombok:lombok'
+    annotationProcessor "org.projectlombok:lombok-mapstruct-binding:0.2.0" // lombok 에서 mapstruct binding 해주는 기능
+    //MySQL Driver
+    runtimeOnly 'com.mysql:mysql-connector-j'
+    //H2 Driver
+    runtimeOnly 'com.h2database:h2'
+    // RestDocs API SPEC
+    testImplementation 'com.epages:restdocs-api-spec-mockmvc:0.16.2'
+    // Swagger UI
+    swaggerUI 'org.webjars:swagger-ui:4.11.1'
+    // JWT
+    implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+    implementation 'io.jsonwebtoken:jjwt-impl:0.11.5'
+    implementation 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+    // MapStruct
+    implementation 'org.mapstruct:mapstruct:1.5.3.Final'
+    annotationProcessor 'org.mapstruct:mapstruct-processor:1.5.3.Final'
+    // p6spy
+    implementation 'com.github.gavlyukovskiy:p6spy-spring-boot-starter:1.8.1'
 
-	// https://mvnrepository.com/artifact/org.hibernate/hibernate-spatial
-	implementation 'org.hibernate:hibernate-spatial'
-	//https://mvnrepository.com/artifact/org.locationtech.jts/jts-core
-	implementation 'org.locationtech.jts:jts-core:1.19.0'
+    // https://mvnrepository.com/artifact/org.hibernate/hibernate-spatial
+    implementation 'org.hibernate:hibernate-spatial'
+    //https://mvnrepository.com/artifact/org.locationtech.jts/jts-core
+    implementation 'org.locationtech.jts:jts-core:1.19.0'
 }
 
 
 tasks.named('test') {
-	outputs.dir snippetsDir
-	useJUnitPlatform()
+    outputs.dir snippetsDir
+    useJUnitPlatform()
 }
 
 tasks.named('asciidoctor') {
-	inputs.dir snippetsDir
-	dependsOn test
+    inputs.dir snippetsDir
+    dependsOn test
 }
 
 asciidoctor.doFirst {
-	delete file('src/main/resources/static/docs')
+    delete file('src/main/resources/static/docs')
 }
 
 tasks.withType(GenerateSwaggerUI).configureEach {
-	dependsOn 'openapi3'
+    dependsOn 'openapi3'
 }
 
 tasks.register('copySwaggerUI', Copy) {
-	dependsOn 'generateSwaggerUISample'
+    dependsOn 'generateSwaggerUISample'
 
-	def generateSwaggerUISampleTask = tasks.named('generateSwaggerUISample', GenerateSwaggerUI).get()
+    def generateSwaggerUISampleTask = tasks.named('generateSwaggerUISample', GenerateSwaggerUI).get()
 
-	from("${generateSwaggerUISampleTask.outputDir}")
-	into("${project.buildDir}/resources/main/static/docs/api/.")
+    from("${generateSwaggerUISampleTask.outputDir}")
+    into("${project.buildDir}/resources/main/static/docs/api/.")
 }
 
 task copyDocument(type: Copy) {
-	dependsOn asciidoctor
-	from file("build/docs/asciidoc")
-	into file("src/main/resources/static/docs")
+    dependsOn asciidoctor
+    from file("build/docs/asciidoc")
+    into file("src/main/resources/static/docs")
 }
 
 tasks.withType(BootJar).configureEach {
-	dependsOn 'copySwaggerUI'
+    dependsOn 'copySwaggerUI'
 }

--- a/src/main/java/com/prgrms/mukvengers/domain/user/api/UserController.java
+++ b/src/main/java/com/prgrms/mukvengers/domain/user/api/UserController.java
@@ -1,0 +1,66 @@
+package com.prgrms.mukvengers.domain.user.api;
+
+import static org.springframework.http.HttpStatus.*;
+
+import javax.validation.Valid;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.prgrms.mukvengers.domain.user.dto.request.UpdateUserRequest;
+import com.prgrms.mukvengers.domain.user.dto.response.UserProfileResponse;
+import com.prgrms.mukvengers.domain.user.service.UserService;
+import com.prgrms.mukvengers.global.common.dto.ApiResponse;
+import com.prgrms.mukvengers.global.security.jwt.JwtAuthentication;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/api/v1/user")
+@RequiredArgsConstructor
+public class UserController {
+
+	private final UserService userService;
+
+	@GetMapping("/{userId}")
+	public ResponseEntity<ApiResponse<UserProfileResponse>> getUserProfile(
+		@PathVariable Long userId
+	) {
+		return ResponseEntity.ok()
+			.body(new ApiResponse<>(userService.getUserProfile(userId)));
+	}
+
+	@GetMapping("/me")
+	public ResponseEntity<ApiResponse<UserProfileResponse>> getMyProfile(
+		@AuthenticationPrincipal JwtAuthentication user
+	) {
+		return ResponseEntity.ok()
+			.body(new ApiResponse<>(userService.getUserProfile(user.id())));
+	}
+
+	@PutMapping("/me")
+	public ResponseEntity<ApiResponse<UserProfileResponse>> updateMyProfile(
+		@RequestBody @Valid UpdateUserRequest updateUserRequest,
+		@AuthenticationPrincipal JwtAuthentication user
+	) {
+		return ResponseEntity.ok()
+			.body(new ApiResponse<>(userService.updateUserProfile(updateUserRequest, user.id())));
+	}
+
+	@DeleteMapping("/me")
+	@ResponseStatus(NO_CONTENT)
+	public void deleteMyProfile(
+		@AuthenticationPrincipal JwtAuthentication user
+	) {
+		userService.deleteUser(user.id());
+	}
+
+}

--- a/src/main/java/com/prgrms/mukvengers/domain/user/exception/UserNotFoundException.java
+++ b/src/main/java/com/prgrms/mukvengers/domain/user/exception/UserNotFoundException.java
@@ -5,11 +5,11 @@ import com.prgrms.mukvengers.global.exception.ServiceException;
 
 public class UserNotFoundException extends ServiceException {
 
-	private static final ErrorCode errorCode = ErrorCode.NOT_FOUND_MEMBER;
-	private static final String messageKey = "exception.user.notfound";
+	private static final ErrorCode ERROR_CODE = ErrorCode.USER_NOT_FOUND;
+	private static final String MESSAGE_KEY = "exception.user.notfound";
 
 	public UserNotFoundException(Long userId) {
-		super(errorCode, messageKey, new Object[] {userId});
+		super(ERROR_CODE, MESSAGE_KEY, new Object[] {userId});
 	}
 
 }

--- a/src/main/java/com/prgrms/mukvengers/domain/user/model/User.java
+++ b/src/main/java/com/prgrms/mukvengers/domain/user/model/User.java
@@ -3,6 +3,8 @@ package com.prgrms.mukvengers.domain.user.model;
 import static javax.persistence.GenerationType.*;
 import static lombok.AccessLevel.*;
 
+import java.util.Objects;
+
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
@@ -106,6 +108,10 @@ public class User extends BaseEntity {
 		this.profileImgUrl = validateProfileImgUrl(updateUserRequest.profileImgUrl());
 		this.introduction = validateIntroduction(updateUserRequest.introduction());
 		return this;
+	}
+
+	public boolean isSameUser(Long userId) {
+		return Objects.equals(this.id, userId);
 	}
 
 }

--- a/src/main/java/com/prgrms/mukvengers/global/config/security/SecurityConfig.java
+++ b/src/main/java/com/prgrms/mukvengers/global/config/security/SecurityConfig.java
@@ -4,36 +4,53 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
-import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
-import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
-import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.oauth2.client.web.OAuth2AuthorizationRequestRedirectFilter;
 import org.springframework.security.web.SecurityFilterChain;
+
+import com.prgrms.mukvengers.global.security.jwt.JwtAuthenticationEntryPoint;
+import com.prgrms.mukvengers.global.security.jwt.JwtAuthenticationFilter;
+import com.prgrms.mukvengers.global.security.token.exception.ExceptionHandlerFilter;
+
+import lombok.RequiredArgsConstructor;
 
 @Configuration
 @EnableWebSecurity
+@RequiredArgsConstructor
 public class SecurityConfig {
+
+	private final JwtAuthenticationFilter jwtAuthenticationFilter;
+	private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
+	private final ExceptionHandlerFilter exceptionHandlerFilter;
 
 	@Bean
 	public SecurityFilterChain httpSecurity(HttpSecurity http) throws Exception {
 		return http
-			.csrf().disable()
 			.cors()
 			.and()
-			.authorizeRequests()
-			.antMatchers("/**").permitAll()
+			.authorizeHttpRequests()
+			.antMatchers("/tokens").permitAll()
+			.antMatchers("/docs/**").permitAll()
+			.antMatchers("/favicon.ico").permitAll()
+			.antMatchers("/api/v1/sample").permitAll()
+			.anyRequest().authenticated()
 			.and()
+			.httpBasic().disable()
+			.rememberMe().disable()
+			.csrf().disable()
+			.logout().disable()
+			.requestCache().disable()
+			.formLogin().disable()
+			.headers().disable()
+			.sessionManagement()
+			.sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+			.and()
+			.exceptionHandling()
+			.authenticationEntryPoint(jwtAuthenticationEntryPoint)
+			.and()
+			.addFilterBefore(jwtAuthenticationFilter, OAuth2AuthorizationRequestRedirectFilter.class)
+			.addFilterBefore(exceptionHandlerFilter, JwtAuthenticationFilter.class)
 			.build();
-	}
-
-	@Bean
-	public WebSecurityCustomizer webSecurityCustomizer() {
-		return web -> web.ignoring()
-			.antMatchers("/**");
-	}
-
-	@Bean
-	public PasswordEncoder passwordEncoder() {
-		return new BCryptPasswordEncoder();
 	}
 
 }

--- a/src/main/java/com/prgrms/mukvengers/global/config/security/SecurityConfig.java
+++ b/src/main/java/com/prgrms/mukvengers/global/config/security/SecurityConfig.java
@@ -33,6 +33,7 @@ public class SecurityConfig {
 			.antMatchers("/docs/**").permitAll()
 			.antMatchers("/favicon.ico").permitAll()
 			.antMatchers("/api/v1/sample").permitAll()
+			.antMatchers("/api/v1/stores/**").permitAll()
 			.anyRequest().authenticated()
 			.and()
 			.httpBasic().disable()

--- a/src/main/java/com/prgrms/mukvengers/global/config/web/WebConfig.java
+++ b/src/main/java/com/prgrms/mukvengers/global/config/web/WebConfig.java
@@ -2,15 +2,16 @@ package com.prgrms.mukvengers.global.config.web;
 
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.EnableWebMvc;
 import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
-import org.springframework.web.servlet.config.annotation.WebMvcConfigurationSupport;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
-
+@EnableWebMvc
 @Configuration
-public class WebConfig extends WebMvcConfigurationSupport {
+public class WebConfig implements WebMvcConfigurer {
 
 	@Override
-	protected void addCorsMappings(CorsRegistry registry) {
+	public void addCorsMappings(CorsRegistry registry) {
 		registry.addMapping("/**")
 			.allowedOriginPatterns("http://localhost:8080/", "/**")
 			.allowedMethods("GET", "POST", "PUT", "PATCH", "DELETE")
@@ -18,7 +19,7 @@ public class WebConfig extends WebMvcConfigurationSupport {
 	}
 
 	@Override
-	protected void addResourceHandlers(ResourceHandlerRegistry registry) {
+	public void addResourceHandlers(ResourceHandlerRegistry registry) {
 		registry.addResourceHandler("/docs/**")
 			.addResourceLocations("classpath:/static/docs/");
 	}

--- a/src/main/java/com/prgrms/mukvengers/global/exception/ErrorCode.java
+++ b/src/main/java/com/prgrms/mukvengers/global/exception/ErrorCode.java
@@ -12,15 +12,20 @@ public enum ErrorCode {
 
 	// Common
 	INVALID_INPUT_VALUE(HttpStatus.BAD_REQUEST, "C001", "잘못된 입력 값입니다."),
-	METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, "C002", "메소드를 사용할 수 없습니다."),
-	INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "C003", "서버 에러입니다."),
-	INVALID_TYPE_VALUE(HttpStatus.BAD_REQUEST, "C004", "잘못된 타입입니다."),
-	HANDLE_ACCESS_DENIED(HttpStatus.FORBIDDEN, "C005", "접근 권한이 없습니다."),
-	MISSING_INPUT_VALUE(HttpStatus.BAD_REQUEST, "C006", "인자가 부족합니다."),
-	NOT_EXIST_API(HttpStatus.BAD_REQUEST, "C007", " 잘못된 URL입니다."),
+	INVALID_TYPE_VALUE(HttpStatus.BAD_REQUEST, "C002", "잘못된 타입입니다."),
+	MISSING_INPUT_VALUE(HttpStatus.BAD_REQUEST, "C003", "인자가 부족합니다."),
+	NOT_EXIST_API(HttpStatus.BAD_REQUEST, "C004", "요청 주소가 올바르지 않습니다."),
+	METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, "C005", "사용할 수 없는 메서드입니다."),
+	HANDLE_ACCESS_DENIED(HttpStatus.FORBIDDEN, "C006", "접근 권한이 없습니다."),
+	INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "C007", "서버 에러입니다."),
 
 	// User
-	NOT_FOUND_MEMBER(HttpStatus.NOT_FOUND, "U001", "존재하지 않는 사용자입니다.");
+	USER_NOT_FOUND(HttpStatus.NOT_FOUND, "U001", "존재하지 않는 사용자입니다."),
+
+	// Auth
+	INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "A001", "유효하지 않은 토큰입니다."),
+	EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, "A002", "만료된 토큰입니다."),
+	NOT_FOUND_TOKEN(HttpStatus.UNAUTHORIZED, "A002", "로그인이 필요합니다.");
 
 	private final HttpStatus status;
 	private final String code;

--- a/src/main/java/com/prgrms/mukvengers/global/security/jwt/JwtAuthentication.java
+++ b/src/main/java/com/prgrms/mukvengers/global/security/jwt/JwtAuthentication.java
@@ -1,0 +1,37 @@
+package com.prgrms.mukvengers.global.security.jwt;
+
+import java.util.Objects;
+
+import com.prgrms.mukvengers.global.security.token.exception.InvalidTokenException;
+
+public record JwtAuthentication(
+	Long id,
+	String accessToken
+
+) {
+	public JwtAuthentication {
+		validateId(id);
+		validateToken(accessToken);
+	}
+
+	private void validateToken(String accessToken) {
+		if (Objects.isNull(accessToken) || accessToken.isBlank()) {
+			throw new InvalidTokenException();
+		}
+	}
+
+	private void validateId(Long userId) {
+		if (Objects.isNull(userId) || userId <= 0L) {
+			throw new InvalidTokenException();
+		}
+	}
+
+	@Override
+	public String toString() {
+		return "JwtAuthentication{" +
+			"accessToken='" + accessToken + '\'' +
+			", id='" + id + '\'' +
+			'}';
+	}
+
+}

--- a/src/main/java/com/prgrms/mukvengers/global/security/jwt/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/com/prgrms/mukvengers/global/security/jwt/JwtAuthenticationEntryPoint.java
@@ -1,0 +1,42 @@
+package com.prgrms.mukvengers.global.security.jwt;
+
+import static org.springframework.http.HttpStatus.*;
+
+import java.io.IOException;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.prgrms.mukvengers.global.common.dto.ErrorResponse;
+import com.prgrms.mukvengers.global.exception.ErrorCode;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+	private static final String ERROR_LOG_MESSAGE = "[ERROR] {} : {}";
+
+	private final ObjectMapper objectMapper;
+
+	@Override
+	public void commence(HttpServletRequest request, HttpServletResponse response,
+		AuthenticationException authException) throws IOException {
+		log.info(ERROR_LOG_MESSAGE, authException.getClass().getSimpleName(), authException.getMessage());
+		response.setStatus(UNAUTHORIZED.value());
+		response.setContentType("application/json");
+		response.setCharacterEncoding("UTF-8");
+		response.getWriter()
+			.write(objectMapper.writeValueAsString(
+				ErrorResponse.of(ErrorCode.HANDLE_ACCESS_DENIED))
+			);
+	}
+}

--- a/src/main/java/com/prgrms/mukvengers/global/security/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/prgrms/mukvengers/global/security/jwt/JwtAuthenticationFilter.java
@@ -1,0 +1,71 @@
+package com.prgrms.mukvengers.global.security.jwt;
+
+import java.io.IOException;
+import java.util.List;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import com.prgrms.mukvengers.global.utils.ExtractUtil;
+
+import io.jsonwebtoken.Claims;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+	private final JwtTokenProvider jwtTokenProvider;
+
+	@Override
+	protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
+		FilterChain filterChain) throws ServletException, IOException {
+
+		String accessToken = getAccessToken(request);
+		if (accessToken != null) {
+			JwtAuthenticationToken authentication = createAuthentication(accessToken);
+			SecurityContextHolder.getContext().setAuthentication(authentication);
+		}
+		filterChain.doFilter(request, response);
+	}
+
+	@Override
+	protected boolean shouldNotFilter(HttpServletRequest request) {
+		return request.getRequestURI().endsWith("tokens")
+			&& request.getMethod().equalsIgnoreCase("POST");
+	}
+
+	private String getAccessToken(HttpServletRequest request) {
+		String token = ExtractUtil.extractTokenFromRequest(request);
+		if (token != null) {
+			jwtTokenProvider.validateToken(token);
+		}
+		return token;
+	}
+
+	private JwtAuthenticationToken createAuthentication(String accessToken) {
+		Claims claims = jwtTokenProvider.getClaims(accessToken);
+
+		Long userId = claims.get("userId", Long.class);
+		String role = claims.get("role", String.class);
+
+		JwtAuthentication principal = new JwtAuthentication(userId, accessToken);
+
+		return new JwtAuthenticationToken(principal, null, toAuthorities(role));
+	}
+
+	private List<GrantedAuthority> toAuthorities(String role) {
+		return List.of(new SimpleGrantedAuthority(role));
+	}
+
+}

--- a/src/main/java/com/prgrms/mukvengers/global/security/jwt/JwtAuthenticationToken.java
+++ b/src/main/java/com/prgrms/mukvengers/global/security/jwt/JwtAuthenticationToken.java
@@ -1,0 +1,66 @@
+package com.prgrms.mukvengers.global.security.jwt;
+
+import java.util.Collection;
+
+import org.springframework.security.authentication.AbstractAuthenticationToken;
+import org.springframework.security.core.GrantedAuthority;
+
+public class JwtAuthenticationToken extends AbstractAuthenticationToken {
+
+	private final Object principal;
+	private String credentials;
+
+	public JwtAuthenticationToken(Object principal, Collection<? extends GrantedAuthority> authorities) {
+		this(principal, null, authorities);
+	}
+
+	public JwtAuthenticationToken(String principal, String credentials) {
+		super(null);
+		super.setAuthenticated(false);
+
+		this.principal = principal;
+		this.credentials = credentials;
+	}
+
+	public JwtAuthenticationToken(
+		Object principal, String credentials, Collection<? extends GrantedAuthority> authorities
+	) {
+		super(authorities);
+		super.setAuthenticated(true);
+
+		this.principal = principal;
+		this.credentials = credentials;
+	}
+
+	@Override
+	public Object getPrincipal() {
+		return principal;
+	}
+
+	@Override
+	public String getCredentials() {
+		return credentials;
+	}
+
+	@Override
+	public void setAuthenticated(boolean isAuthenticated) {
+		if (isAuthenticated) {
+			throw new IllegalArgumentException("유효하지 않은 접근입니다.");
+		}
+		super.setAuthenticated(false);
+	}
+
+	@Override
+	public void eraseCredentials() {
+		super.eraseCredentials();
+		credentials = null;
+	}
+
+	@Override
+	public String toString() {
+		return "JwtAuthenticationToken{"
+			+ "principal=" + principal
+			+ ", credentials='" + credentials + '\''
+			+ '}';
+	}
+}

--- a/src/main/java/com/prgrms/mukvengers/global/security/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/prgrms/mukvengers/global/security/jwt/JwtTokenProvider.java
@@ -1,0 +1,72 @@
+package com.prgrms.mukvengers.global.security.jwt;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
+import java.util.Map;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import com.prgrms.mukvengers.global.security.token.exception.ExpiredTokenException;
+import com.prgrms.mukvengers.global.security.token.exception.InvalidTokenException;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+
+@Component
+public class JwtTokenProvider {
+
+	private static final long MILLI_SECOND = 1000L;
+
+	private final String issuer;
+	private final String secretKey;
+	private final long accessTokenExpirySeconds;
+
+	public JwtTokenProvider(
+		@Value("${jwt.issuer}") String issuer,
+		@Value("${jwt.secret-key}") String secretKey,
+		@Value("${jwt.expiry-seconds.access-token}") long accessTokenExpirySeconds) {
+		this.issuer = issuer;
+		this.secretKey = secretKey;
+		this.accessTokenExpirySeconds = accessTokenExpirySeconds;
+	}
+
+	public String createAccessToken(Long userId, String role) {
+		Map<String, Object> claims = Map.of("userId", userId, "role", role);
+		Date now = new Date();
+		Date expiredDate = new Date(now.getTime() + accessTokenExpirySeconds * MILLI_SECOND);
+
+		return Jwts.builder()
+			.setIssuer(issuer)
+			.setClaims(claims)
+			.setIssuedAt(now)
+			.setExpiration(expiredDate)
+			.signWith(Keys.hmacShaKeyFor(secretKey.getBytes(StandardCharsets.UTF_8)))
+			.compact();
+	}
+
+	public Claims getClaims(String token) {
+		return Jwts.parserBuilder()
+			.setSigningKey(Keys.hmacShaKeyFor(secretKey.getBytes(StandardCharsets.UTF_8)))
+			.build()
+			.parseClaimsJws(token)
+			.getBody();
+	}
+
+	public void validateToken(String token) {
+		try {
+			Jwts.parserBuilder()
+				.setSigningKey(Keys.hmacShaKeyFor(secretKey.getBytes(StandardCharsets.UTF_8)))
+				.build()
+				.parseClaimsJws(token);
+		} catch (ExpiredJwtException e) {
+			throw new ExpiredTokenException();
+		} catch (JwtException | IllegalArgumentException e) {
+			throw new InvalidTokenException();
+		}
+	}
+
+}

--- a/src/main/java/com/prgrms/mukvengers/global/security/token/exception/ExceptionHandlerFilter.java
+++ b/src/main/java/com/prgrms/mukvengers/global/security/token/exception/ExceptionHandlerFilter.java
@@ -1,0 +1,46 @@
+package com.prgrms.mukvengers.global.security.token.exception;
+
+import java.io.IOException;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.prgrms.mukvengers.global.common.dto.ErrorResponse;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ExceptionHandlerFilter extends OncePerRequestFilter {
+
+	private final ObjectMapper objectMapper;
+
+	@Override
+	protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
+		FilterChain filterChain) throws ServletException, IOException {
+		try {
+			filterChain.doFilter(request, response);
+		} catch (TokenException e) {
+			log.debug("[ExceptionHandler] token error message = {}", e.getMessage());
+			generateErrorResponse(response, e);
+		}
+	}
+
+	private void generateErrorResponse(HttpServletResponse response, TokenException e) throws IOException {
+		response.setStatus(e.getErrorCode().getStatus().value());
+		response.setContentType("application/json");
+		response.setCharacterEncoding("UTF-8");
+		response.getWriter()
+			.write(objectMapper.writeValueAsString(
+				ErrorResponse.of(e.getErrorCode())));
+	}
+
+}

--- a/src/main/java/com/prgrms/mukvengers/global/security/token/exception/ExpiredTokenException.java
+++ b/src/main/java/com/prgrms/mukvengers/global/security/token/exception/ExpiredTokenException.java
@@ -1,0 +1,14 @@
+package com.prgrms.mukvengers.global.security.token.exception;
+
+import com.prgrms.mukvengers.global.exception.ErrorCode;
+
+public class ExpiredTokenException extends TokenException {
+
+	private static final ErrorCode ERROR_CODE = ErrorCode.EXPIRED_TOKEN;
+	private static final String MESSAGE_KEY = "exception.token.expired";
+
+	public ExpiredTokenException() {
+		super(ERROR_CODE, MESSAGE_KEY);
+	}
+
+}

--- a/src/main/java/com/prgrms/mukvengers/global/security/token/exception/InvalidTokenException.java
+++ b/src/main/java/com/prgrms/mukvengers/global/security/token/exception/InvalidTokenException.java
@@ -1,0 +1,14 @@
+package com.prgrms.mukvengers.global.security.token.exception;
+
+import com.prgrms.mukvengers.global.exception.ErrorCode;
+
+public class InvalidTokenException extends TokenException {
+
+	private static final ErrorCode ERROR_CODE = ErrorCode.INVALID_TOKEN;
+	private static final String MESSAGE_KEY = "exception.token.invalid";
+
+	public InvalidTokenException() {
+		super(ERROR_CODE, MESSAGE_KEY);
+	}
+
+}

--- a/src/main/java/com/prgrms/mukvengers/global/security/token/exception/TokenException.java
+++ b/src/main/java/com/prgrms/mukvengers/global/security/token/exception/TokenException.java
@@ -1,0 +1,11 @@
+package com.prgrms.mukvengers.global.security.token.exception;
+
+import com.prgrms.mukvengers.global.exception.ErrorCode;
+import com.prgrms.mukvengers.global.exception.ServiceException;
+
+public abstract class TokenException extends ServiceException {
+
+	protected TokenException(ErrorCode errorCode, String messageKey) {
+		super(errorCode, messageKey, null);
+	}
+}

--- a/src/main/java/com/prgrms/mukvengers/global/utils/ExtractUtil.java
+++ b/src/main/java/com/prgrms/mukvengers/global/utils/ExtractUtil.java
@@ -1,0 +1,29 @@
+package com.prgrms.mukvengers.global.utils;
+
+import static lombok.AccessLevel.*;
+import static org.springframework.http.HttpHeaders.*;
+
+import javax.servlet.http.HttpServletRequest;
+
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = PRIVATE)
+public class ExtractUtil {
+
+	private static final String BEARER_TYPE = "Bearer";
+
+	public static String extractTokenFromRequest(HttpServletRequest request) {
+		String authHeaderValue = request.getHeader(AUTHORIZATION);
+		if (authHeaderValue != null) {
+			return extractToken(authHeaderValue);
+		}
+		return null;
+	}
+
+	private static String extractToken(String authHeaderValue) {
+		if (authHeaderValue.toLowerCase().startsWith(BEARER_TYPE.toLowerCase())) {
+			return authHeaderValue.substring(BEARER_TYPE.length()).trim();
+		}
+		return null;
+	}
+}

--- a/src/main/resources/application-security.yml
+++ b/src/main/resources/application-security.yml
@@ -2,7 +2,8 @@
 jwt:
   issuer: ${JWT_ISSUER}
   secret-key: ${JWT_SECRET_KEY}
-  expiry-seconds: 3600
+  expiry-seconds:
+    access-token: 3600
 
 spring:
   security:

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -38,4 +38,5 @@ logging:
 jwt:
   issuer: ${JWT_ISSUER}
   secret-key: ${JWT_SECRET_KEY}
-  expiry-seconds: 2
+  expiry-seconds:
+    access-token: 10

--- a/src/test/java/com/prgrms/mukvengers/base/ControllerTest.java
+++ b/src/test/java/com/prgrms/mukvengers/base/ControllerTest.java
@@ -1,5 +1,6 @@
 package com.prgrms.mukvengers.base;
 
+import static com.prgrms.mukvengers.utils.UserObjectProvider.*;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.*;
 import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.*;
 
@@ -19,20 +20,35 @@ import org.springframework.web.filter.CharacterEncodingFilter;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.prgrms.mukvengers.config.RestDocsConfig;
+import com.prgrms.mukvengers.domain.user.model.User;
+import com.prgrms.mukvengers.domain.user.repository.UserRepository;
+import com.prgrms.mukvengers.global.security.jwt.JwtTokenProvider;
 
 @Transactional
-@ExtendWith(RestDocumentationExtension.class)
-@Import({RestDocsConfig.class})
 @SpringBootTest
+@Import({RestDocsConfig.class})
+@ExtendWith(RestDocumentationExtension.class)
 public abstract class ControllerTest {
+
+	protected final String BEARER_TYPE = "Bearer ";
 
 	@Autowired
 	protected RestDocumentationResultHandler restDocs;
 
 	@Autowired
+	protected JwtTokenProvider jwtTokenProvider;
+
+	@Autowired
+	protected UserRepository userRepository;
+
+	@Autowired
 	protected ObjectMapper objectMapper;
 
 	protected MockMvc mockMvc;
+
+	protected User savedUser;
+	protected Long savedUserId;
+	protected String ACCESS_TOKEN;
 
 	@BeforeEach
 	void setUpRestDocs(WebApplicationContext webApplicationContext,
@@ -43,6 +59,13 @@ public abstract class ControllerTest {
 			.apply(springSecurity())
 			.alwaysDo(restDocs)
 			.build();
+	}
+
+	@BeforeEach
+	void setUpLogin() {
+		savedUser = userRepository.save(createUser());
+		savedUserId = savedUser.getId();
+		ACCESS_TOKEN = jwtTokenProvider.createAccessToken(savedUserId, "USER");
 	}
 
 }

--- a/src/test/java/com/prgrms/mukvengers/config/JwtConfig.java
+++ b/src/test/java/com/prgrms/mukvengers/config/JwtConfig.java
@@ -1,0 +1,20 @@
+package com.prgrms.mukvengers.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+
+import com.prgrms.mukvengers.global.security.jwt.JwtTokenProvider;
+
+@TestConfiguration
+public class JwtConfig {
+
+	@Bean
+	public JwtTokenProvider jwtTokenProvider(
+		@Value("${jwt.issuer}") String issuer,
+		@Value("${jwt.secret-key}") String secretKey,
+		@Value("${jwt.expiry-seconds.access-token}") int accessTokenExpirySeconds
+	) {
+		return new JwtTokenProvider(issuer, secretKey, accessTokenExpirySeconds);
+	}
+}

--- a/src/test/java/com/prgrms/mukvengers/domain/user/api/UserControllerTest.java
+++ b/src/test/java/com/prgrms/mukvengers/domain/user/api/UserControllerTest.java
@@ -1,0 +1,134 @@
+package com.prgrms.mukvengers.domain.user.api;
+
+import static com.prgrms.mukvengers.utils.UserObjectProvider.*;
+import static org.springframework.restdocs.payload.JsonFieldType.*;
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
+
+import com.prgrms.mukvengers.base.ControllerTest;
+import com.prgrms.mukvengers.domain.user.dto.request.UpdateUserRequest;
+import com.prgrms.mukvengers.domain.user.model.User;
+
+class UserControllerTest extends ControllerTest {
+
+	@Test
+	@DisplayName("[성공] 사용자는 자신의 프로필 정보를 확인할 수 있다")
+	void getMyProfileSuccessTest() throws Exception {
+		// when
+		mockMvc.perform(RestDocumentationRequestBuilders.get("/api/v1/user/me")
+				.header(HttpHeaders.AUTHORIZATION, BEARER_TYPE + ACCESS_TOKEN)
+			)
+			// then
+			.andExpectAll(
+				handler().methodName("getMyProfile"),
+				status().isOk())
+			// docs
+			.andDo(restDocs.document(
+				responseFields(
+					fieldWithPath("data.id").type(NUMBER).description("유저 ID"),
+					fieldWithPath("data.nickname").type(STRING).description("닉네임"),
+					fieldWithPath("data.profileImgUrl").type(STRING).description("프로필 이미지"),
+					fieldWithPath("data.introduction").type(STRING).description("한줄 소개"),
+					fieldWithPath("data.leaderCount").type(NUMBER).description("방장 횟수"),
+					fieldWithPath("data.leaderCount").type(NUMBER).description("방장 횟수"),
+					fieldWithPath("data.crewCount").type(NUMBER).description("모임 참여 횟수"),
+					fieldWithPath("data.tasteScore").type(NUMBER).description("맛잘알 점수"),
+					fieldWithPath("data.mannerScore").type(NUMBER).description("매너 온도")
+
+				))
+			);
+	}
+
+	@Test
+	@DisplayName("[성공] 유저 아이디로 유저 정보를 조회할 수 있다.")
+	void getUserProfileSuccessTest() throws Exception {
+		// when
+		mockMvc.perform(RestDocumentationRequestBuilders
+				.get("/api/v1/user/{userId}", savedUserId)
+				.header(HttpHeaders.AUTHORIZATION, BEARER_TYPE + ACCESS_TOKEN)
+			)
+			// then
+			.andExpectAll(
+				handler().methodName("getUserProfile"),
+				status().isOk())
+			// docs
+			.andDo(restDocs.document(
+				responseFields(
+					fieldWithPath("data.id").type(NUMBER).description("유저 ID"),
+					fieldWithPath("data.nickname").type(STRING).description("닉네임"),
+					fieldWithPath("data.profileImgUrl").type(STRING).description("프로필 이미지"),
+					fieldWithPath("data.introduction").type(STRING).description("한줄 소개"),
+					fieldWithPath("data.leaderCount").type(NUMBER).description("방장 횟수"),
+					fieldWithPath("data.leaderCount").type(NUMBER).description("방장 횟수"),
+					fieldWithPath("data.crewCount").type(NUMBER).description("모임 참여 횟수"),
+					fieldWithPath("data.tasteScore").type(NUMBER).description("맛잘알 점수"),
+					fieldWithPath("data.mannerScore").type(NUMBER).description("매너 온도")
+				))
+			);
+	}
+
+	@Test
+	@DisplayName("[성공] 자신의 프로필을 수정할 수 있다.")
+	void updateMyProfileSuccessTest() throws Exception {
+		UpdateUserRequest request = getUpdateUserRequest();
+
+		// when
+		mockMvc.perform(RestDocumentationRequestBuilders.put("/api/v1/user/me")
+				.header(HttpHeaders.AUTHORIZATION, BEARER_TYPE + ACCESS_TOKEN)
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(request))
+			)
+			// then
+			.andExpectAll(
+				handler().methodName("updateMyProfile"),
+				status().isOk())
+			// docs
+			.andDo(restDocs.document(
+				responseFields(
+					fieldWithPath("data.id").type(NUMBER).description("유저 ID"),
+					fieldWithPath("data.nickname").type(STRING).description("닉네임"),
+					fieldWithPath("data.profileImgUrl").type(STRING).description("프로필 이미지"),
+					fieldWithPath("data.introduction").type(STRING).description("한줄 소개"),
+					fieldWithPath("data.leaderCount").type(NUMBER).description("방장 횟수"),
+					fieldWithPath("data.leaderCount").type(NUMBER).description("방장 횟수"),
+					fieldWithPath("data.crewCount").type(NUMBER).description("모임 참여 횟수"),
+					fieldWithPath("data.tasteScore").type(NUMBER).description("맛잘알 점수"),
+					fieldWithPath("data.mannerScore").type(NUMBER).description("매너 온도")
+				))
+			);
+
+	}
+
+	@Test
+	@DisplayName("자신의 계정을 삭제할 수 있다")
+	void deleteMyProfileSuccessTest() throws Exception {
+
+		//given
+		User createdUser = User.builder()
+			.nickname(DEFAULT_NICKNAME)
+			.profileImgUrl(DEFAULT_PROFILE_IMG_URL)
+			.provider(PROVIDER_KAKAO)
+			.oauthId(OAUTH_ID)
+			.build();
+
+		User user = userRepository.save(createdUser);
+		Long userId = user.getId();
+		String token = jwtTokenProvider.createAccessToken(userId, "USER");
+
+		// when
+		mockMvc.perform(RestDocumentationRequestBuilders.delete("/api/v1/user/me")
+				.header(HttpHeaders.AUTHORIZATION, BEARER_TYPE + token)
+			)
+			// then
+			.andExpectAll(
+				handler().methodName("deleteMyProfile"),
+				status().isNoContent()
+			);
+	}
+}

--- a/src/test/java/com/prgrms/mukvengers/domain/user/model/UserTest.java
+++ b/src/test/java/com/prgrms/mukvengers/domain/user/model/UserTest.java
@@ -1,0 +1,80 @@
+package com.prgrms.mukvengers.domain.user.model;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+
+class UserTest {
+
+	private static final String email = "test@test.com";
+	private static final String nickName = "테스터";
+	private static final String introduce = "테스트하는 중";
+	private static final String prologName = "테스터의 prolog";
+	private static final String provider = "kakao";
+	private static final String oauthId = "1";
+	private static final String SIZE_255_STRING_DUMMY = "0" + "1234567890".repeat(26);
+
+	private static Stream<Arguments> provideStringDummy() {
+		return Stream.of(
+			Arguments.of("  ", true),
+			Arguments.of(SIZE_255_STRING_DUMMY, true)
+		);
+	}
+
+	@Test
+	@DisplayName("[성공] 유저 생성")
+	void createTest() {
+		//given & when
+		User user = User.builder()
+			.nickname("테스트")
+			.profileImgUrl("https://defaultImg.jpg")
+			.provider("kakao")
+			.oauthId("12345")
+			.build();
+		//then
+		assertThat(user)
+			.hasFieldOrPropertyWithValue("nickname", "테스트")
+			.hasFieldOrPropertyWithValue("profileImgUrl", "https://defaultImg.jpg")
+			.hasFieldOrPropertyWithValue("introduction", "자기소개를 작성해주세요")
+			.hasFieldOrPropertyWithValue("leaderCount", 0)
+			.hasFieldOrPropertyWithValue("crewCount", 0)
+			.hasFieldOrPropertyWithValue("tasteScore", 0)
+			.hasFieldOrPropertyWithValue("mannerScore", 36.5)
+			.hasFieldOrPropertyWithValue("provider", "kakao")
+			.hasFieldOrPropertyWithValue("oauthId", "12345")
+			.hasFieldOrPropertyWithValue("reportedCount", 0)
+			.hasFieldOrPropertyWithValue("enabled", false);
+	}
+
+	@ParameterizedTest
+	@DisplayName("nickName 유효성 검증")
+	@NullAndEmptySource
+	@MethodSource("provideStringDummy")
+	void nickNameValidateTest(String inputNickName) {
+		//given & when & then
+		assertThatThrownBy(() -> getBuilder().nickname(inputNickName).build())
+			.isInstanceOf(IllegalArgumentException.class);
+	}
+
+	@ParameterizedTest
+	@DisplayName("자기 소개 유효성 검증")
+	@NullAndEmptySource
+	@MethodSource("provideStringDummy")
+	void emailValidateTest(String inputIntroduce) {
+		//given & when & then
+		assertThatThrownBy(() -> getBuilder().nickname(inputIntroduce).build())
+			.isInstanceOf(IllegalArgumentException.class);
+	}
+
+	private User.UserBuilder getBuilder() {
+		return User.builder();
+	}
+
+}

--- a/src/test/java/com/prgrms/mukvengers/domain/user/repository/UserRepositoryTest.java
+++ b/src/test/java/com/prgrms/mukvengers/domain/user/repository/UserRepositoryTest.java
@@ -23,14 +23,8 @@ class UserRepositoryTest extends RepositoryTest {
 	@DisplayName("[성공] 유저 엔티티를 저장할 수 있다.")
 	void saveSuccessTest() {
 		// given
-		User user = User.builder()
-			.nickname("테스트")
-			.profileImgUrl("https://defaultImg.jpg")
-			.provider("kakao")
-			.oauthId("12345")
-			.build();
 		// when
-		User savedUser = userRepository.save(user);
+		User savedUser = userRepository.save(createUser());
 		Optional<User> foundUser = userRepository.findById(savedUser.getId());
 		// then
 		assertThat(foundUser).isPresent();

--- a/src/test/java/com/prgrms/mukvengers/global/security/jwt/JwtAuthenticationFilterTest.java
+++ b/src/test/java/com/prgrms/mukvengers/global/security/jwt/JwtAuthenticationFilterTest.java
@@ -1,0 +1,107 @@
+package com.prgrms.mukvengers.global.security.jwt;
+
+import static com.prgrms.mukvengers.utils.UserObjectProvider.*;
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.io.IOException;
+
+import javax.servlet.ServletException;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpHeaders;
+import org.springframework.mock.web.MockFilterChain;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+import com.prgrms.mukvengers.global.security.token.exception.ExpiredTokenException;
+import com.prgrms.mukvengers.global.security.token.exception.InvalidTokenException;
+import com.prgrms.mukvengers.global.utils.ExtractUtil;
+
+class JwtAuthenticationFilterTest {
+
+	private static final String BEARER_TYPE = "Bearer ";
+	private static final String ISSUER = "issuer";
+	private static final String SECRET_KEY = "kkini-team-kkini-project-fighting";
+	private static final int ACCESS_TOKEN_EXPIRY_SECONDS = 1;
+	private static final String USER_ROLE = "USER";
+
+	private JwtAuthenticationFilter jwtAuthenticationFilter;
+	private JwtTokenProvider jwtTokenProvider;
+	private MockHttpServletRequest request;
+	private MockHttpServletResponse response;
+	private MockFilterChain filterChain;
+	private String ACCESS_TOKEN;
+
+	@BeforeEach
+	void setUp() {
+		request = new MockHttpServletRequest();
+		response = new MockHttpServletResponse();
+		filterChain = new MockFilterChain();
+		jwtTokenProvider = new JwtTokenProvider(ISSUER, SECRET_KEY, ACCESS_TOKEN_EXPIRY_SECONDS);
+		jwtAuthenticationFilter = new JwtAuthenticationFilter(jwtTokenProvider);
+		ACCESS_TOKEN = jwtTokenProvider.createAccessToken(USER_ID, USER_ROLE);
+	}
+
+	@DisplayName("[성공] 헤더(Authorization Bearer)에서 토큰을 추출할 수 있다.")
+	@Test
+	void extractTokenFromRequestSuccessTest() {
+		// given
+		request.addHeader(HttpHeaders.AUTHORIZATION, BEARER_TYPE + ACCESS_TOKEN);
+		// when
+		String token = ExtractUtil.extractTokenFromRequest(request);
+		// then
+		assertDoesNotThrow(() -> jwtTokenProvider.validateToken(token));
+	}
+
+	@DisplayName("[성공] 유효한 Access Token이 헤더에 있는 경우 인증된 사용자 정보(userId, token)가 SecurityContextHolder에 저장된다.")
+	@Test
+	void doFilterInternalSuccessTest() throws ServletException, IOException {
+		// given
+		request.addHeader(HttpHeaders.AUTHORIZATION, BEARER_TYPE + ACCESS_TOKEN);
+		// when
+		jwtAuthenticationFilter.doFilterInternal(request, response, filterChain);
+		// then
+
+		// 현재 SecurityContext에 들어 있는 인증된 사용자(principal) 추출
+		JwtAuthentication user = (JwtAuthentication)
+			SecurityContextHolder
+				.getContext()
+				.getAuthentication()
+				.getPrincipal();
+
+		assertThat(user)
+			.hasFieldOrPropertyWithValue("id", USER_ID)
+			.hasFieldOrPropertyWithValue("accessToken", ACCESS_TOKEN);
+	}
+
+	@DisplayName("[실패] 유효한 Access Token이 헤더에 있는 경우")
+	@Test
+	void doFilterInternal_InvalidToken() {
+		// given
+		String invalidToken = "invalidToken";
+		request.addHeader(HttpHeaders.AUTHORIZATION, BEARER_TYPE + invalidToken);
+		// when & then
+		assertThatThrownBy(
+			() -> jwtAuthenticationFilter.doFilterInternal(request, response, filterChain))
+			.isInstanceOf(InvalidTokenException.class);
+
+	}
+
+	@DisplayName("[실패] 만료된 토큰일 경우 예외를 발생한다.")
+	@Test
+	void doFilterInternal_ExpiredToken() {
+		// given
+		JwtTokenProvider jwtTokenProvider = new JwtTokenProvider(ISSUER, SECRET_KEY, 0);
+		String newToken = jwtTokenProvider.createAccessToken(USER_ID, USER_ROLE);
+		request.addHeader(HttpHeaders.AUTHORIZATION, BEARER_TYPE + newToken);
+		// when & then
+		assertThatThrownBy(
+			() -> jwtAuthenticationFilter.doFilterInternal(request, response, filterChain))
+			.isInstanceOf(ExpiredTokenException.class);
+	}
+
+}

--- a/src/test/java/com/prgrms/mukvengers/global/security/jwt/JwtAuthenticationTest.java
+++ b/src/test/java/com/prgrms/mukvengers/global/security/jwt/JwtAuthenticationTest.java
@@ -1,0 +1,51 @@
+package com.prgrms.mukvengers.global.security.jwt;
+
+import static org.assertj.core.api.Assertions.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.NullSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import com.prgrms.mukvengers.global.security.token.exception.InvalidTokenException;
+
+class JwtAuthenticationTest {
+
+	private static final String token = "validToken";
+	private static final long USER_ID = 1L;
+
+	@Test
+	@DisplayName("[성공] token과 유저ID로 인증된 사용자(principal)를 의미하는 jwtAuthentication을 생성할 수 있다.")
+	void createSuccessTest() {
+		// given
+		JwtAuthentication jwtAuthentication
+			= new JwtAuthentication(USER_ID, token);
+		// when & then
+		assertThat(jwtAuthentication)
+			.hasFieldOrPropertyWithValue("id", USER_ID)
+			.hasFieldOrPropertyWithValue("accessToken", token);
+
+	}
+
+	@ParameterizedTest
+	@NullSource
+	@ValueSource(longs = {0L, -1L, -100L})
+	@DisplayName("[실패] userId는 null 혹은 0 이하일 수 없다.")
+	void createFailByInvalidUserIdTest(Long inputUserId) {
+		//given & when & then
+		assertThatThrownBy(() -> new JwtAuthentication(inputUserId, token))
+			.isInstanceOf(InvalidTokenException.class);
+	}
+
+	@ParameterizedTest
+	@NullAndEmptySource
+	@DisplayName("[실패] token은 null 혹은 빈 값일 수 없다.")
+	void createFailByInvalidTokenTest(String inputToken) {
+		//given & when & then
+		assertThatThrownBy(() -> new JwtAuthentication(USER_ID, inputToken))
+			.isInstanceOf(InvalidTokenException.class);
+	}
+
+}

--- a/src/test/java/com/prgrms/mukvengers/global/security/jwt/JwtTokenProviderTest.java
+++ b/src/test/java/com/prgrms/mukvengers/global/security/jwt/JwtTokenProviderTest.java
@@ -1,6 +1,5 @@
 package com.prgrms.mukvengers.global.security.jwt;
 
-import static com.prgrms.mukvengers.utils.TestConstant.*;
 import static com.prgrms.mukvengers.utils.UserObjectProvider.*;
 import static org.assertj.core.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.*;
@@ -14,6 +13,11 @@ import com.prgrms.mukvengers.global.security.token.exception.InvalidTokenExcepti
 import io.jsonwebtoken.Claims;
 
 class JwtTokenProviderTest {
+
+	private static final String ISSUER = "issuer";
+	private static final String SECRET_KEY = "kkini-team-kkini-project-fighting";
+	private static final int ACCESS_TOKEN_EXPIRY_SECONDS = 1;
+	private static final String USER_ROLE = "USER";
 
 	private final JwtTokenProvider jwtTokenProvider
 		= new JwtTokenProvider(ISSUER, SECRET_KEY, ACCESS_TOKEN_EXPIRY_SECONDS);

--- a/src/test/java/com/prgrms/mukvengers/global/security/jwt/JwtTokenProviderTest.java
+++ b/src/test/java/com/prgrms/mukvengers/global/security/jwt/JwtTokenProviderTest.java
@@ -1,0 +1,114 @@
+package com.prgrms.mukvengers.global.security.jwt;
+
+import static com.prgrms.mukvengers.utils.TestConstant.*;
+import static com.prgrms.mukvengers.utils.UserObjectProvider.*;
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import com.prgrms.mukvengers.global.security.token.exception.ExpiredTokenException;
+import com.prgrms.mukvengers.global.security.token.exception.InvalidTokenException;
+
+import io.jsonwebtoken.Claims;
+
+class JwtTokenProviderTest {
+
+	private final JwtTokenProvider jwtTokenProvider
+		= new JwtTokenProvider(ISSUER, SECRET_KEY, ACCESS_TOKEN_EXPIRY_SECONDS);
+
+	@Test
+	@DisplayName("[성공] 페이로드(유저ID, ROLE)를 담은 JWT를 생성할 수 있다.")
+	void createAccessTokenSuccessTest() {
+		// given : 유저 아이디와 권한에 대해 100% 유효함을 보장하지는 못한다.
+		Long userId = 0L;
+		String role = "ROLE";
+		// when & then
+		assertDoesNotThrow(() -> jwtTokenProvider.createAccessToken(userId, role));
+	}
+
+	@Test
+	@DisplayName("[성공] JWT에서 페이로드(유저ID, ROLE)를 추출할 수 있다.")
+	void getClaimsSuccessTest() {
+		// given
+		String token = jwtTokenProvider.createAccessToken(USER_ID, USER_ROLE);
+		// when
+		Claims claims = jwtTokenProvider.getClaims(token);
+		// then
+		assertAll(
+			() -> assertThat(claims.get("userId", Long.class)).isEqualTo(USER_ID),
+			() -> assertThat(claims.get("role", String.class)).isEqualTo(USER_ROLE)
+		);
+	}
+
+	@Test
+	@DisplayName("[성공] 토큰 값을 유효성 검사할 수 있다. 유효한 토큰의 경우 예외를 발생시키지 않는다.")
+	void validateTokenSuccessTest() {
+		// given
+		String token = jwtTokenProvider.createAccessToken(1L, "role");
+
+		// when & then
+		assertDoesNotThrow(() -> jwtTokenProvider.validateToken(token));
+	}
+
+	@Test
+	@DisplayName("[실패] 토큰의 만료 시간이 지나면 ExpiredTokenException 예외를 발생한다.")
+	void validateTokenFailByExpiredTest() throws Exception {
+		// given
+		String token = jwtTokenProvider.createAccessToken(1L, "role");
+		Thread.sleep(ACCESS_TOKEN_EXPIRY_SECONDS * 1000L);
+		// when & then
+		assertThatThrownBy(() -> jwtTokenProvider.validateToken(token))
+			.isInstanceOf(ExpiredTokenException.class);
+	}
+
+	@Test
+	@DisplayName("[실패] 유효하지 않은 토큰 검증시 InvalidTokenException 예외를 발생한다.")
+	void validateTokenFailByInvalidTest() {
+		// given
+		String token = "InvalidToken";
+		// when & then
+		assertThatThrownBy(() -> jwtTokenProvider.validateToken(token))
+			.isInstanceOf(InvalidTokenException.class);
+	}
+
+	@Test
+	@DisplayName("[성공] 토큰 값이 null인 경우 InvalidTokenException이 발생한다.")
+	void validateTokenFailByNullTest() {
+		// given
+		String token = null;
+		// when & then
+		assertThatThrownBy(() -> jwtTokenProvider.validateToken(token))
+			.isInstanceOf(InvalidTokenException.class);
+	}
+
+	@Test
+	@DisplayName("[성공] 발행자 정보가 달라도 예외가 발생하지 않는다.????")
+	void validateTokenFailByWrongIssuerTest() {
+		// given
+		String invalidIssuer = "wrong-issuer";
+		JwtTokenProvider wongTokenProvider
+			= new JwtTokenProvider(invalidIssuer, SECRET_KEY, ACCESS_TOKEN_EXPIRY_SECONDS);
+		//when
+		String token = wongTokenProvider.createAccessToken(USER_ID, USER_ROLE);
+		//then
+		assertDoesNotThrow(() -> jwtTokenProvider.validateToken(token));
+		assertDoesNotThrow(() -> jwtTokenProvider.getClaims(token));
+	}
+
+	@Test
+	@DisplayName("[실패] 올바르지 않은 시그니처(시크릿 키)로 검증 시 예외를 발생한다.")
+	void validateTokenFailByWrongSignTest() {
+		// given
+		String invalidSecretKey = "we-inherited-the-blood-of-the-DarkKnight";
+		JwtTokenProvider wongTokenProvider
+			= new JwtTokenProvider(ISSUER, invalidSecretKey, ACCESS_TOKEN_EXPIRY_SECONDS);
+		//when
+		String token = wongTokenProvider.createAccessToken(USER_ID, USER_ROLE);
+		//then
+		assertThatThrownBy(() -> jwtTokenProvider.validateToken(token))
+			.isInstanceOf(InvalidTokenException.class);
+	}
+
+}

--- a/src/test/java/com/prgrms/mukvengers/utils/UserObjectProvider.java
+++ b/src/test/java/com/prgrms/mukvengers/utils/UserObjectProvider.java
@@ -5,6 +5,7 @@ import com.prgrms.mukvengers.domain.user.model.User;
 
 public class UserObjectProvider {
 
+	public static final Long USER_ID = 1L;
 	public static final String DEFAULT_NICKNAME = "끼니";
 	public static final String DEFAULT_PROFILE_IMG_URL = "https://defaultImg.jpg";
 	public static final String PROVIDER_KAKAO = "kakao";

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -2,3 +2,4 @@ spring:
   profiles:
     include:
       - test
+      - security


### PR DESCRIPTION
### 🌱 작업 사항 
두가지 기능을 구현해서 하나의 PR로 만들어서 올렸습니다.. 빨리 구현해야 해서 같이 올린점 양해 부탁드립니다!
#### JWT 기반 인증 기능
- JWT 의존성 설정(변경)
  - com.auth0:java-jwt => io.jsonwebtoken:jjwt 변경
  - jjwt가 레퍼런스가 더 많고 손 쉽게 사용가능해서 변경했습니다 
- TokenException 계층
   - Security에서 발생할 수 있는 Token 관련 예외 추상화
   - InvalidTokenException: 올바르지 않은 토큰인 경우 발생할 수 있는 예외 (시크릿 키가 다르거나, 정상적이지 않은 JWT 형태,등 시큐리티에서 JWT 관련으로 나타날 수 있는 예외)
   - ExpiredTokenException: 정상적인 토큰이지만 만료 시간이 지난 토큰을 사용할 때 발생하는 예외
- JwtAuthenticationFilter
  - 시큐리티 인증 필터
  - 헤더에 accessToken이 있을때 동작
  - 토큰이 유효하지 않으면 예외 발생
  - 유효한 토큰 존재시 인증 객체 만들어서 SecurityContextHolder에 넣어줌
  - 테스트 코드 추가했습니다. 동작을 확인해보셔도 좋을 것 같아요
- JwtAuthenticationToken
  - 인증 객체를 담는 그릇: 시큐리티 필터에서 인증 객체를 전달하는데 사용됨
  - 인증 사용자 객체, credentials(자격 증명서), 권한
  - DTO 역할인 것 같아서 따로 테스트를 작성하지는 않았습니다
- JwtAuthentication
  - 인증된 사용자를 의미하는 객체
  - id, accessToken을 필드로 가짐
  - 추후에 변경해볼 예정
  - @AuthenticationPrincipal에서 주입해주는 객체
  - 단순 유효성 검증 테스트만 진행했습니다
- ExtractUtil
  - 요청 헤더에서 토큰 정보를 추출하는 유틸성 클래스
  - 헤더 명[Authorization Bearer ] + 토큰 형태
- JwtAuthenticationEntryPoint
  - 토큰이 없어서 인증하지 못했을 때 동작하는 필터
- ExceptionHandlerFilter 
  - 인증할 때 예외(TokenException) 발생시 동작하는 필터
- @AuthenticationPrincipal이 정상동작하지 않는 문제 해결
   - @EnableWebMvc 추가
   - WebMvcConfigurationSupport => WebMvcConfigurer 변경
   - protected -> public
   - addArgumentResolvers 동작 과정 공부하기
#### 유저 Controller
 - @AuthenticationPrincipal로 userId 받기(시큐리티 기능 사용)
- ControllerTest에 자주 사용되는 유저 미리 세팅
- 인증 절차 진행 후 동작하는지 테스트함
- swaggerUI는 추후에 확인해서 변경할 예정
### ❓ 리뷰 포인트
- 내용이 이해가 잘 안된다면 댓글 부탁드립니다.
- 컨베션이나 규칙이 틀린게 있는지 확인 부탁드립니다.. (제가 많이 틀리네요.. 죄송합니다!)
- 더 좋은 구현 방법이 떠오른다면 편하게 제안해주세요! 
### 🦄 관련 이슈
resolve #3, #8  