### PR TITLE
[#28] OAuth를 이용해서 kakao 및 google 로그인 기능 구현 

### DIFF
--- a/src/main/java/com/prgrms/mukvengers/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/prgrms/mukvengers/domain/user/repository/UserRepository.java
@@ -1,9 +1,22 @@
 package com.prgrms.mukvengers.domain.user.repository;
 
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import com.prgrms.mukvengers.domain.user.model.User;
 
 public interface UserRepository extends JpaRepository<User, Long> {
 
+	@Query("""
+		SELECT u
+		FROM User u
+		WHERE u.provider = :provider
+		and u.oauthId = :oauthId
+		""")
+	Optional<User> findByUserIdByProviderAndOauthId(
+		@Param("provider") String provider,
+		@Param("oauthId") String oauthId);
 }

--- a/src/main/java/com/prgrms/mukvengers/global/config/security/SecurityConfig.java
+++ b/src/main/java/com/prgrms/mukvengers/global/config/security/SecurityConfig.java
@@ -10,6 +10,9 @@ import org.springframework.security.web.SecurityFilterChain;
 
 import com.prgrms.mukvengers.global.security.jwt.JwtAuthenticationEntryPoint;
 import com.prgrms.mukvengers.global.security.jwt.JwtAuthenticationFilter;
+import com.prgrms.mukvengers.global.security.oauth.handler.HttpCookieOAuthAuthorizationRequestRepository;
+import com.prgrms.mukvengers.global.security.oauth.handler.OAuthAuthenticationFailureHandler;
+import com.prgrms.mukvengers.global.security.oauth.handler.OAuthAuthenticationSuccessHandler;
 import com.prgrms.mukvengers.global.security.token.exception.ExceptionHandlerFilter;
 
 import lombok.RequiredArgsConstructor;
@@ -21,6 +24,9 @@ public class SecurityConfig {
 
 	private final JwtAuthenticationFilter jwtAuthenticationFilter;
 	private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
+	private final OAuthAuthenticationSuccessHandler oauthAuthenticationSuccessHandler;
+	private final OAuthAuthenticationFailureHandler oauthAuthenticationFailureHandler;
+	private final HttpCookieOAuthAuthorizationRequestRepository httpCookieOAuthAuthorizationRequestRepository;
 	private final ExceptionHandlerFilter exceptionHandlerFilter;
 
 	@Bean
@@ -30,7 +36,7 @@ public class SecurityConfig {
 			.and()
 			.authorizeHttpRequests()
 			.antMatchers("/tokens").permitAll()
-			.antMatchers("/docs/**").permitAll()
+			.antMatchers("/oauth2/**").permitAll()
 			.antMatchers("/favicon.ico").permitAll()
 			.antMatchers("/api/v1/sample").permitAll()
 			.antMatchers("/api/v1/stores/**").permitAll()
@@ -46,6 +52,13 @@ public class SecurityConfig {
 			.sessionManagement()
 			.sessionCreationPolicy(SessionCreationPolicy.STATELESS)
 			.and()
+			.oauth2Login()
+			.authorizationEndpoint().baseUri("/oauth2/authorization")
+			.authorizationRequestRepository(httpCookieOAuthAuthorizationRequestRepository)
+			.and()
+			.successHandler(oauthAuthenticationSuccessHandler)
+			.failureHandler(oauthAuthenticationFailureHandler)
+			.and()
 			.exceptionHandling()
 			.authenticationEntryPoint(jwtAuthenticationEntryPoint)
 			.and()
@@ -53,6 +66,5 @@ public class SecurityConfig {
 			.addFilterBefore(exceptionHandlerFilter, JwtAuthenticationFilter.class)
 			.build();
 	}
-
 }
 

--- a/src/main/java/com/prgrms/mukvengers/global/security/oauth/dto/OAuthUserInfo.java
+++ b/src/main/java/com/prgrms/mukvengers/global/security/oauth/dto/OAuthUserInfo.java
@@ -1,0 +1,12 @@
+package com.prgrms.mukvengers.global.security.oauth.dto;
+
+import lombok.Builder;
+
+@Builder
+public record OAuthUserInfo(
+	String nickname,
+	String profileImgUrl,
+	String provider,
+	String oauthId
+) {
+}

--- a/src/main/java/com/prgrms/mukvengers/global/security/oauth/handler/HttpCookieOAuthAuthorizationRequestRepository.java
+++ b/src/main/java/com/prgrms/mukvengers/global/security/oauth/handler/HttpCookieOAuthAuthorizationRequestRepository.java
@@ -1,0 +1,54 @@
+package com.prgrms.mukvengers.global.security.oauth.handler;
+
+import static org.springframework.util.StringUtils.*;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.springframework.security.oauth2.client.web.AuthorizationRequestRepository;
+import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest;
+import org.springframework.stereotype.Repository;
+
+import com.prgrms.mukvengers.global.utils.CookieUtil;
+
+@Repository
+public class HttpCookieOAuthAuthorizationRequestRepository implements
+	AuthorizationRequestRepository<OAuth2AuthorizationRequest> {
+
+	public static final String OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME = "oauth2_auth_request";
+	public static final String REDIRECT_URI_PARAM_COOKIE_NAME = "redirect_uri";
+	private static final int COOKIE_EXPIRE_SECONDS = 180;
+
+	@Override
+	public OAuth2AuthorizationRequest loadAuthorizationRequest(HttpServletRequest request) {
+		return CookieUtil.getCookie(request, OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME)
+			.map(cookie -> CookieUtil.deserialize(cookie, OAuth2AuthorizationRequest.class))
+			.orElse(null);
+	}
+
+	@Override
+	public void saveAuthorizationRequest(OAuth2AuthorizationRequest authorizationRequest,
+		HttpServletRequest request, HttpServletResponse response) {
+		if (authorizationRequest == null) {
+			removeAuthorizationRequestCookies(request, response);
+			return;
+		}
+		CookieUtil.addCookie(response, OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME,
+			CookieUtil.serialize(authorizationRequest), COOKIE_EXPIRE_SECONDS);
+		String redirectUriAfterLogin = request.getParameter(REDIRECT_URI_PARAM_COOKIE_NAME);
+		if (hasText(redirectUriAfterLogin)) {
+			CookieUtil.addCookie(response, REDIRECT_URI_PARAM_COOKIE_NAME, redirectUriAfterLogin,
+				COOKIE_EXPIRE_SECONDS);
+		}
+	}
+
+	@Override
+	public OAuth2AuthorizationRequest removeAuthorizationRequest(HttpServletRequest request) {
+		return this.loadAuthorizationRequest(request);
+	}
+
+	public void removeAuthorizationRequestCookies(HttpServletRequest request, HttpServletResponse response) {
+		CookieUtil.deleteCookie(request, response, OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME);
+		CookieUtil.deleteCookie(request, response, REDIRECT_URI_PARAM_COOKIE_NAME);
+	}
+}

--- a/src/main/java/com/prgrms/mukvengers/global/security/oauth/handler/OAuthAuthenticationFailureHandler.java
+++ b/src/main/java/com/prgrms/mukvengers/global/security/oauth/handler/OAuthAuthenticationFailureHandler.java
@@ -1,0 +1,45 @@
+package com.prgrms.mukvengers.global.security.oauth.handler;
+
+import static com.prgrms.mukvengers.global.security.oauth.handler.HttpCookieOAuthAuthorizationRequestRepository.*;
+
+import java.io.IOException;
+
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.authentication.SimpleUrlAuthenticationFailureHandler;
+import org.springframework.stereotype.Component;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import com.prgrms.mukvengers.global.utils.CookieUtil;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class OAuthAuthenticationFailureHandler
+	extends SimpleUrlAuthenticationFailureHandler {
+
+	private static final String DEFAULT_TARGET_URL = "/";
+	private final HttpCookieOAuthAuthorizationRequestRepository httpCookieOAuthAuthorizationRequestRepository;
+
+	@Override
+	public void onAuthenticationFailure(HttpServletRequest request, HttpServletResponse response,
+		AuthenticationException exception) throws IOException {
+		String redirectUrl = CookieUtil.getCookie(request, REDIRECT_URI_PARAM_COOKIE_NAME)
+			.map(Cookie::getValue)
+			.orElse(DEFAULT_TARGET_URL);
+
+		String targetUrl = UriComponentsBuilder.fromUriString(redirectUrl)
+			.queryParam("error", exception.getMessage())
+			.build().toUriString();
+
+		httpCookieOAuthAuthorizationRequestRepository.removeAuthorizationRequestCookies(request, response);
+
+		getRedirectStrategy().sendRedirect(request, response, targetUrl);
+	}
+}
+
+

--- a/src/main/java/com/prgrms/mukvengers/global/security/oauth/handler/OAuthAuthenticationSuccessHandler.java
+++ b/src/main/java/com/prgrms/mukvengers/global/security/oauth/handler/OAuthAuthenticationSuccessHandler.java
@@ -1,0 +1,67 @@
+package com.prgrms.mukvengers.global.security.oauth.handler;
+
+import static com.prgrms.mukvengers.global.security.oauth.handler.HttpCookieOAuthAuthorizationRequestRepository.*;
+import static org.springframework.http.HttpHeaders.*;
+
+import java.io.IOException;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.springframework.security.core.Authentication;
+import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.security.web.authentication.SavedRequestAwareAuthenticationSuccessHandler;
+import org.springframework.stereotype.Component;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import com.prgrms.mukvengers.global.security.oauth.service.OAuthService;
+import com.prgrms.mukvengers.global.utils.CookieUtil;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class OAuthAuthenticationSuccessHandler
+	extends SavedRequestAwareAuthenticationSuccessHandler {
+
+	private static final String BEARER_TYPE = "Bearer ";
+
+	private final OAuthService oauthService;
+
+	@Override
+	public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response,
+		Authentication authentication) throws IOException, ServletException {
+
+		if (authentication instanceof OAuth2AuthenticationToken authenticationToken) {
+			OAuth2User oauth2User = authenticationToken.getPrincipal();
+			String providerName = authenticationToken.getAuthorizedClientRegistrationId();
+			String accessToken = oauthService.login(oauth2User, providerName);
+			String redirectUrl = getRedirectUrl(request, accessToken);
+			setResponse(response, accessToken);
+			getRedirectStrategy().sendRedirect(request, response, redirectUrl);
+
+		} else {
+			super.onAuthenticationSuccess(request, response, authentication);
+		}
+	}
+
+	private String getRedirectUrl(HttpServletRequest request, String accessToken) {
+		String targetUrl = CookieUtil.getCookie(request, REDIRECT_URI_PARAM_COOKIE_NAME)
+			.map(Cookie::getValue)
+			.orElse(getDefaultTargetUrl());
+
+		return UriComponentsBuilder.fromUriString(targetUrl)
+			.queryParam("accessToken", accessToken) // url에도 실어 보내기
+			.build().toUriString();
+	}
+
+	private void setResponse(HttpServletResponse response, String accessToken) {
+		response.setHeader(AUTHORIZATION, BEARER_TYPE + accessToken); // 헤더 값이 사라짐..
+		response.addCookie(new Cookie("token", accessToken)); // 임시로 쿠키에 담아서 보내기
+	}
+}

--- a/src/main/java/com/prgrms/mukvengers/global/security/oauth/mapper/OAuthMapper.java
+++ b/src/main/java/com/prgrms/mukvengers/global/security/oauth/mapper/OAuthMapper.java
@@ -1,0 +1,13 @@
+package com.prgrms.mukvengers.global.security.oauth.mapper;
+
+import org.mapstruct.Mapper;
+
+import com.prgrms.mukvengers.domain.user.model.User;
+import com.prgrms.mukvengers.global.security.oauth.dto.OAuthUserInfo;
+
+@Mapper(componentModel = "spring")
+public interface OAuthMapper { // TODO: UserMapper로 옮겨야 하나?
+
+	User toUser(OAuthUserInfo oauthUserInfo);
+
+}

--- a/src/main/java/com/prgrms/mukvengers/global/security/oauth/service/OAuthProvider.java
+++ b/src/main/java/com/prgrms/mukvengers/global/security/oauth/service/OAuthProvider.java
@@ -1,0 +1,64 @@
+package com.prgrms.mukvengers.global.security.oauth.service;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.springframework.security.oauth2.core.user.OAuth2User;
+
+import com.prgrms.mukvengers.global.security.oauth.dto.OAuthUserInfo;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum OAuthProvider {
+
+	KAKAO("kakao") {
+		@Override
+		public OAuthUserInfo toUserInfo(OAuth2User oauth2User) {
+			Map<String, Object> attributes = oauth2User.getAttributes();
+			Map<String, Object> properties = oauth2User.getAttribute("properties");
+
+			return OAuthUserInfo.builder()
+				.provider(KAKAO.name)
+				.oauthId(String.valueOf(attributes.get("id")))
+				.nickname(String.valueOf(attributes.get("nickname")))
+				.profileImgUrl(String.valueOf(properties.get("profile_image")))
+				.build();
+		}
+	},
+
+	GOOGLE("google") {
+		@Override
+		public OAuthUserInfo toUserInfo(OAuth2User oauth2User) {
+			Map<String, Object> attributes = oauth2User.getAttributes();
+
+			return OAuthUserInfo.builder()
+				.provider(GOOGLE.name)
+				.oauthId(String.valueOf(oauth2User.getName()))
+				.nickname(String.valueOf(attributes.get("name")))
+				.profileImgUrl(String.valueOf(attributes.get("picture")))
+				.build();
+		}
+	};
+
+	private static final Map<String, OAuthProvider> PROVIDERS =
+		Collections.unmodifiableMap(Stream.of(values())
+			.collect(Collectors.toMap(OAuthProvider::getName, Function.identity())));
+
+	private final String name;
+
+	public static OAuthProvider getOAuthProviderByName(String providerName) {
+		if (!PROVIDERS.containsKey(providerName)) { // TODO: 가독성 떨어지나요?
+			throw new IllegalArgumentException("지원하지 않는 로그인입니다.");
+		}
+		return PROVIDERS.get(providerName);
+	}
+
+	public abstract OAuthUserInfo toUserInfo(OAuth2User oauth2User);
+
+}

--- a/src/main/java/com/prgrms/mukvengers/global/security/oauth/service/OAuthService.java
+++ b/src/main/java/com/prgrms/mukvengers/global/security/oauth/service/OAuthService.java
@@ -1,0 +1,41 @@
+package com.prgrms.mukvengers.global.security.oauth.service;
+
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.prgrms.mukvengers.domain.user.model.User;
+import com.prgrms.mukvengers.domain.user.repository.UserRepository;
+import com.prgrms.mukvengers.global.security.jwt.JwtTokenProvider;
+import com.prgrms.mukvengers.global.security.oauth.dto.OAuthUserInfo;
+import com.prgrms.mukvengers.global.security.oauth.mapper.OAuthMapper;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class OAuthService {
+
+	private final JwtTokenProvider jwtTokenProvider;
+	private final UserRepository userRepository;
+	private final OAuthMapper oauthMapper;
+
+	@Transactional
+	public String login(OAuth2User oauth2User, String providerName) {
+
+		OAuthUserInfo oauthUserInfo = OAuthProvider
+			.getOAuthProviderByName(providerName)
+			.toUserInfo(oauth2User);
+
+		// TODO: user로 옮겨야 하나?
+		User user = userRepository
+			.findByUserIdByProviderAndOauthId(oauthUserInfo.provider(), oauthUserInfo.oauthId())
+			.orElseGet(() -> userRepository.save(oauthMapper.toUser(oauthUserInfo)));
+
+		String accessToken = jwtTokenProvider.createAccessToken(user.getId(), "ROLE_USER");
+		log.debug("{}를 통해 로그인 한 사용자(ID: {}), accessToken = {}", providerName, user.getId(), accessToken);
+		return accessToken;
+	}
+}

--- a/src/main/java/com/prgrms/mukvengers/global/utils/CookieUtil.java
+++ b/src/main/java/com/prgrms/mukvengers/global/utils/CookieUtil.java
@@ -1,0 +1,70 @@
+package com.prgrms.mukvengers.global.utils;
+
+import static lombok.AccessLevel.*;
+
+import java.util.Arrays;
+import java.util.Base64;
+import java.util.Optional;
+
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.springframework.util.SerializationUtils;
+
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = PRIVATE)
+public class CookieUtil {
+
+	public static Optional<Cookie> getCookie(HttpServletRequest request, String name) {
+		Cookie[] cookies = request.getCookies();
+
+		if (cookies != null && cookies.length > 0) {
+			return Arrays.stream(cookies)
+				.filter(cookie -> cookie.getName().equals(name))
+				.findFirst();
+		}
+
+		return Optional.empty();
+	}
+
+	public static void addCookie(HttpServletResponse response, String name, String value,
+		int maxAge) {
+		Cookie cookie = new Cookie(name, value);
+		cookie.setPath("/");
+		cookie.setHttpOnly(true);
+		cookie.setMaxAge(maxAge);
+		response.addCookie(cookie);
+	}
+
+	public static void deleteCookie(HttpServletRequest request, HttpServletResponse response,
+		String name) {
+		Cookie[] cookies = request.getCookies();
+
+		if (cookies != null) {
+			Arrays.stream(cookies)
+				.filter(cookie -> cookie.getName().equals(name))
+				.findFirst()
+				.ifPresent(cookie -> {
+					cookie.setValue("");
+					cookie.setPath("/");
+					cookie.setMaxAge(0);
+					response.addCookie(cookie);
+				});
+		}
+	}
+
+	public static String serialize(Object object) {
+		return Base64.getUrlEncoder()
+			.encodeToString(SerializationUtils.serialize(object));
+	}
+
+	public static <T> T deserialize(Cookie cookie, Class<T> cls) {
+		return cls.cast(SerializationUtils.deserialize(
+			Base64.getUrlDecoder().decode(cookie.getValue())
+		));
+	}
+}
+
+

--- a/src/main/resources/application-security.yml
+++ b/src/main/resources/application-security.yml
@@ -5,20 +5,24 @@ jwt:
   expiry-seconds:
     access-token: 3600
 
+# OAuth 2.0 설정
 spring:
   security:
     oauth2:
       client:
         registration:
+          google:
+            client-id: ${GOOGLE_CLIENT_ID}
+            client-secret: ${GOOGLE_CLIENT_SECRET}
+            scope: profile
           kakao:
             client-name: kakao
-            client-id: ${CLIENT_ID}
-            client-secret: ${CLIENT_SECRET}
+            client-id: ${KAKAO_CLIENT_ID}
+            client-secret: ${KAKAO_CLIENT_SECRET}
             scope:
               - profile_nickname
               - profile_image
-              - account_email
-            redirect-uri: ${REDIRECT_URI}
+            redirect-uri: ${KAKAO_REDIRECT_URI}
             authorization-grant-type: authorization_code
             client-authentication-method: POST
         provider:


### PR DESCRIPTION
### 🌱 작업 사항 
 - [config(Security): application-security.yml에 구글 OAuth 설정 추가](https://github.com/prgrms-web-devcourse/Team-Kkini-Mukvengers-BE/commit/097a3b73a14f3f0fb070057fa4332fbd84a4f475)
   - client-id, client-secret 추가
   - 구글과 카카오 변수 구분하기 
 - [feat(OAuth): 리소스 서버에서 받아온 데이터를 변환하는 기능(객체)들 구현](https://github.com/prgrms-web-devcourse/Team-Kkini-Mukvengers-BE/commit/bb7cfa4dddc16d37d4bd1371e3dbf749ba1842a7)
    - OAuthProvider: 리소스 서버에 맞게 OAuth2User -> OAuthUserInfo 로 변환하는 역할
      - ENUM으로 관리 (팀원과 상의 후 결정)
      - HashMap으로 최적화 적용
      - 리뷰 포인트: 가독성이 떨어지는 확인 바람
      - getOAuthProviderByName에서 발생하는 예외 변경 필요할 듯(추후 고려)
   - OAuthUserInfo: 리소스 서버에서 받아온 데이터를 전달하기 위한 DTO
   - OAuthMapper: OAuthUserInfo -> User로 변환하는 Mapper
     - UserMapper에 있어야 하는지 고민 중(추후 리팩터링 고려 사항)
 - [feat(OAuth): 로그인 기능 구현](https://github.com/prgrms-web-devcourse/Team-Kkini-Mukvengers-BE/commit/a2355f48674c774c19dad6cc6df426640f410165)
   - OAuthService 구현
     - OAuthProvider를 통해 리소스 서버에서 받아온 데이터를 변환한 후 DB에 이미 회원으로 등록 되어있는지 검증(provider 이름, oauthId를 통해)해 등록된 경우 로그인 아니라면 등록하는 로직 -> 반환은 JWT 토큰으로 했으나 추후에 리팩토링이 필요
   - UserRepository에 Provider와 OauthId로 찾는 메서드 추가(추후에 DB에 유니크 키로 등록할 필요 있을 듯)
 - [feat(OAuth): OAuth Success, Failure Handler 구현](https://github.com/prgrms-web-devcourse/Team-Kkini-Mukvengers-BE/commit/85d46f9429ff77f6ff1b273951995ac38cc780b9)
    - OAuth 로그인 성공 혹은 실패시 동작할 Handler들
      - 리팩터링이 다소 많이 필요할 것 같습니다!!
    - SuccessHandler: 리소스 서버(카카오, 구글)에서 로그인 성공했을 때 동작
      - 현재 로직은 성공시 가져온 데이터를 통해 DB에 등록 혹은 데이터를 반환하는 과정을 거친 후 프론트 단에서 주문한 곳으로 데이터를 리다이렉트로 보냄
    - FailureHandler: 리소스 서버에서 로그인 실패시 동작
      - 리다이렉트로 프론트 단에 에러를 반환
    - HttpCookieOAuthAuthorizationRequestRepository
      - 리다이렉트 할 주소를 쿠키에 넣어 줌
    - CookieUtil
      - 쿠키에 관련된 기능을 따로 처리하기 위해 만든 유틸성 클래스
- [config(Security): SecurityConfig에 Handler 추가](https://github.com/prgrms-web-devcourse/Team-Kkini-Mukvengers-BE/pull/32/commits/0255fcfbc82c11392278de5c0a1b998ba7c64116)
### ❓ 리뷰 포인트
 - 일단 리팩터링 해야 할 부분이 너무 많습니다. 다만, 1차 스프린트에서 해야되는 부분이기 때문에 구현하고 리뷰를 받고자 합니다.
- 특히, OAuth 데이터를 User로 변환하는 기능이다 보니 중간 중간 User에 역할과 겹치는 부분이 있는 것 같아서 고민이 됩니다..
- SuccessHandler에 너무 많은 기능이 섞여 있다고 생각이 됩니다. 다른 방식으로 나눠보고자 합니다. 팀원분들의 생각이 궁금합니다.
- 아직 쿠키 및 리다이렉트 부분에 대해 잘 몰라서 공부가 필요합니다. 또한, 프론트와 맞춰봐야 하는 부분도 있어서 일단 테스트시에 JWT를 만들 수 있는 포인트를 두려는데 어떻게 생각하시는지 이야기 나누고 싶습니다!
### 🦄 관련 이슈
resolves #28