### PR TITLE
[#39] prod서버에 SSL 인증서 도입 

### DIFF
--- a/.platform/nginx/nginx.conf
+++ b/.platform/nginx/nginx.conf
@@ -31,6 +31,11 @@ http {
   server {
       listen        80 default_server;
 
+      proxy_set_header X-Forwarded-Proto $scheme;
+      if ( $http_x_forwarded_proto != 'https' ){
+        return 301 https://$host$request_uri;
+      }
+
       location / {
           proxy_pass          http://springboot;
           proxy_http_version  1.1;


### PR DESCRIPTION
### 🌱 작업 사항 
- Route53에 도메인 등록 및 SSL 인증서 발급
- Elastic Beanstalk에 로드 벨런서 구성 후 SSL 인증서 적용

- nginx 설정을 변경하여 http(80포트)의 요청을 https(443포트)로 리다이렉트합니다.
- `http_x_forwarded_proto` 헤더는 클라이언트가 접속할 때 사용한 프로토콜을 나타냅니다.

### PR포인트
- 관련해서 간단하게 문서로 남기겠습니다.


