### PR TITLE
[#15] 방장과 밥모임원에 대한 매너온도 및 맛잘알 리뷰 생성 및 조회

### DIFF
--- a/src/main/java/com/prgrms/mukvengers/domain/crew/model/Crew.java
+++ b/src/main/java/com/prgrms/mukvengers/domain/crew/model/Crew.java
@@ -54,8 +54,8 @@ public class Crew extends BaseEntity {
 	private static final Integer MIN_LATITUDE = -90;
 	private static final Integer MAX_LONGITUDE = 180;
 	private static final Integer MIN_LONGITUDE = -180;
-	@OneToMany(mappedBy = "crew")
-	private final List<CrewMember> crewMembers = new ArrayList<>();
+
+
 	@Id
 	@GeneratedValue(strategy = IDENTITY)
 	private Long id;

--- a/src/main/java/com/prgrms/mukvengers/domain/crew/model/Crew.java
+++ b/src/main/java/com/prgrms/mukvengers/domain/crew/model/Crew.java
@@ -59,30 +59,42 @@ public class Crew extends BaseEntity {
 	@Id
 	@GeneratedValue(strategy = IDENTITY)
 	private Long id;
+
 	@ManyToOne(fetch = LAZY)
 	@JoinColumn(name = "leader_id", referencedColumnName = "id")
 	private User leader;
+
 	@OneToOne(fetch = LAZY)
 	@JoinColumn(name = "store_id", referencedColumnName = "id")
 	private Store store;
+
 	@Column(nullable = false, length = 20)
 	private String name;
+
 	@Convert(converter = Store.PointConverter.class)
 	@ColumnTransformer(write = "ST_PointFromText(?, 4326)", read = "ST_AsText(location)")
 	@Column(nullable = false)
 	private Point location;
+
 	@Column(nullable = false)
 	private Integer capacity;
+
+	@Column(nullable = false, length = 255)
 	@Enumerated(STRING)
-	@Column(nullable = false)
 	private Status status;
-	@Column
+
+	@Column(nullable = false)
 	private String content;
+
 	@Enumerated(STRING)
 	@Column(nullable = false)
 	private Category category;
+
 	@Column(nullable = false)
 	private LocalDateTime promiseTime;
+
+	@OneToMany(mappedBy = "crew")
+	private List<CrewMember> crewMembers = new ArrayList<>();
 
 	@Builder
 	protected Crew(User leader, Store store, String name, Point location, Integer capacity, Status status,

--- a/src/main/java/com/prgrms/mukvengers/domain/crew/model/Crew.java
+++ b/src/main/java/com/prgrms/mukvengers/domain/crew/model/Crew.java
@@ -96,6 +96,11 @@ public class Crew extends BaseEntity {
 	@OneToMany(mappedBy = "crew")
 	private List<CrewMember> crewMembers = new ArrayList<>();
 
+	public void addCrewMember(CrewMember crewMember) {
+		crewMembers.add(crewMember);
+	}
+
+
 	@Builder
 	protected Crew(User leader, Store store, String name, Point location, Integer capacity, Status status,
 		String content, Category category, LocalDateTime promiseTime) {

--- a/src/main/java/com/prgrms/mukvengers/domain/crew/repository/CrewRepository.java
+++ b/src/main/java/com/prgrms/mukvengers/domain/crew/repository/CrewRepository.java
@@ -1,6 +1,7 @@
 package com.prgrms.mukvengers.domain.crew.repository;
 
 import java.util.List;
+import java.util.Optional;
 
 import org.locationtech.jts.geom.Point;
 import org.springframework.data.domain.Page;
@@ -27,4 +28,11 @@ public interface CrewRepository extends JpaRepository<Crew, Long> {
 			+ "ORDER BY dist ASC")
 	List<Crew> findAllByLocation(@Param("location") Point location, @Param("distance") int distance);
 
+	@Query("""
+		SELECT c
+		FROM Crew c
+		JOIN FETCH c.crewMembers cm
+		WHERE c.id = :crewId AND c.leader.id = :revieweeId AND cm.user.id = :reviewerId
+		""")
+	Optional<Crew> joinCrewMemberByCrewId(@Param(value = "crewId") Long crewId, @Param(value = "reviewerId") Long reviewerId,@Param(value = "revieweeId") Long revieweeId);
 }

--- a/src/main/java/com/prgrms/mukvengers/domain/crewmember/repository/CrewMemberRepository.java
+++ b/src/main/java/com/prgrms/mukvengers/domain/crewmember/repository/CrewMemberRepository.java
@@ -1,0 +1,19 @@
+package com.prgrms.mukvengers.domain.crewmember.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import com.prgrms.mukvengers.domain.crewmember.model.CrewMember;
+
+public interface CrewMemberRepository extends JpaRepository<CrewMember, Long> {
+
+	@Query("""
+		SELECT cm
+		FROM CrewMember cm
+		WHERE cm.crew.id= :crewId AND cm.user.id = :reviewMemberId
+		""")
+	Optional<CrewMember> findCrewMemberByCrewId(@Param(value = "crewId") Long crewId, @Param(value = "reviewMemberId") Long reviewMemberId);
+}

--- a/src/main/java/com/prgrms/mukvengers/domain/review/api/ReviewController.java
+++ b/src/main/java/com/prgrms/mukvengers/domain/review/api/ReviewController.java
@@ -1,0 +1,76 @@
+package com.prgrms.mukvengers.domain.review.api;
+
+import java.net.URI;
+
+import javax.validation.Valid;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import com.prgrms.mukvengers.domain.review.dto.request.CreateLeaderReviewRequest;
+import com.prgrms.mukvengers.domain.review.dto.request.CreateMemberReviewRequest;
+import com.prgrms.mukvengers.domain.review.dto.response.ReviewResponse;
+import com.prgrms.mukvengers.domain.review.service.ReviewService;
+import com.prgrms.mukvengers.global.common.dto.ApiResponse;
+import com.prgrms.mukvengers.global.common.dto.IdResponse;
+import com.prgrms.mukvengers.global.security.jwt.JwtAuthentication;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1")
+public class ReviewController {
+
+	private final ReviewService reviewService;
+
+	/**
+	 * 밥모임을 생성한 방장에 대한 리뷰를 생성한다.
+	 */
+	@PostMapping("/crews/{crewId}/reviews/leader")
+	public ResponseEntity<IdResponse> createReviewOfLeader
+		(
+			@RequestBody @Valid CreateLeaderReviewRequest createLeaderReviewRequest,
+			@AuthenticationPrincipal JwtAuthentication user,	// 리뷰를 작성하고자 하는 reviewer
+			@PathVariable Long crewId
+		) {
+		IdResponse reviewIdResponse = reviewService.createReviewOfLeader(createLeaderReviewRequest, user.id(), crewId);
+		URI location = UriComponentsBuilder.fromUriString("/api/v1/reviews/" + reviewIdResponse.id()).build().toUri();
+		return ResponseEntity.created(location).build();
+	}
+
+	/**
+	 * 방장을 제외한 밥모임에 참여한 밥모임원에 대한 리뷰를 생성한다.
+	 */
+	@PostMapping("/crews/{crewId}/reviews/member")
+	public ResponseEntity<IdResponse> createReviewOfMember
+		(
+			@Valid @RequestBody CreateMemberReviewRequest createMemberReviewRequest,
+			@AuthenticationPrincipal JwtAuthentication user,
+			@PathVariable Long crewId
+		) {
+		IdResponse reviewIdResponse = reviewService.createMemberReview(createMemberReviewRequest, user.id(), crewId);
+		URI location = UriComponentsBuilder.fromUriString("/api/v1/posts/" + reviewIdResponse.id()).build().toUri();
+		return ResponseEntity.created(location).build();
+	}
+
+	/**
+	 * 상세한 리뷰 조회를 위한 리뷰 단건 조회한다.
+	 */
+	@GetMapping("/reviews/{reviewId}")
+	public ResponseEntity<ApiResponse<ReviewResponse>> getSingleReview
+		(
+			@PathVariable Long reviewId,
+			@AuthenticationPrincipal JwtAuthentication user
+		) {
+		ReviewResponse findReview = reviewService.getSingleReview(reviewId, user.id());
+		return ResponseEntity.ok().body(new ApiResponse<>(findReview));
+	}
+}

--- a/src/main/java/com/prgrms/mukvengers/domain/review/api/ReviewController.java
+++ b/src/main/java/com/prgrms/mukvengers/domain/review/api/ReviewController.java
@@ -37,10 +37,9 @@ public class ReviewController {
 	@PostMapping("/crews/{crewId}/reviews/leader")
 	public ResponseEntity<IdResponse> createReviewOfLeader
 	(
-		@PathVariable Long crewId,
+		@RequestBody @Valid CreateLeaderReviewRequest createLeaderReviewRequest,
 		@AuthenticationPrincipal JwtAuthentication user,    // 리뷰를 작성하고자 하는 reviewer
-		@RequestBody @Valid CreateLeaderReviewRequest createLeaderReviewRequest
-
+		@PathVariable Long crewId
 	) {
 		IdResponse reviewIdResponse = reviewService.createReviewOfLeader(createLeaderReviewRequest, user.id(), crewId);
 		URI location = UriComponentsBuilder.fromUriString("/api/v1/reviews/" + reviewIdResponse.id()).build().toUri();
@@ -53,10 +52,9 @@ public class ReviewController {
 	@PostMapping("/crews/{crewId}/reviews/member")
 	public ResponseEntity<IdResponse> createReviewOfMember
 	(
-		@PathVariable Long crewId,
+		@Valid @RequestBody CreateMemberReviewRequest createMemberReviewRequest,
 		@AuthenticationPrincipal JwtAuthentication user,
-		@Valid @RequestBody CreateMemberReviewRequest createMemberReviewRequest
-
+		@PathVariable Long crewId
 	) {
 		IdResponse reviewIdResponse = reviewService.createMemberReview(createMemberReviewRequest, user.id(), crewId);
 		URI location = UriComponentsBuilder.fromUriString("/api/v1/posts/" + reviewIdResponse.id()).build().toUri();

--- a/src/main/java/com/prgrms/mukvengers/domain/review/api/ReviewController.java
+++ b/src/main/java/com/prgrms/mukvengers/domain/review/api/ReviewController.java
@@ -36,11 +36,12 @@ public class ReviewController {
 	 */
 	@PostMapping("/crews/{crewId}/reviews/leader")
 	public ResponseEntity<IdResponse> createReviewOfLeader
-		(
-			@RequestBody @Valid CreateLeaderReviewRequest createLeaderReviewRequest,
-			@AuthenticationPrincipal JwtAuthentication user,	// 리뷰를 작성하고자 하는 reviewer
-			@PathVariable Long crewId
-		) {
+	(
+		@PathVariable Long crewId,
+		@AuthenticationPrincipal JwtAuthentication user,    // 리뷰를 작성하고자 하는 reviewer
+		@RequestBody @Valid CreateLeaderReviewRequest createLeaderReviewRequest
+
+	) {
 		IdResponse reviewIdResponse = reviewService.createReviewOfLeader(createLeaderReviewRequest, user.id(), crewId);
 		URI location = UriComponentsBuilder.fromUriString("/api/v1/reviews/" + reviewIdResponse.id()).build().toUri();
 		return ResponseEntity.created(location).build();
@@ -51,11 +52,12 @@ public class ReviewController {
 	 */
 	@PostMapping("/crews/{crewId}/reviews/member")
 	public ResponseEntity<IdResponse> createReviewOfMember
-		(
-			@Valid @RequestBody CreateMemberReviewRequest createMemberReviewRequest,
-			@AuthenticationPrincipal JwtAuthentication user,
-			@PathVariable Long crewId
-		) {
+	(
+		@PathVariable Long crewId,
+		@AuthenticationPrincipal JwtAuthentication user,
+		@Valid @RequestBody CreateMemberReviewRequest createMemberReviewRequest
+
+	) {
 		IdResponse reviewIdResponse = reviewService.createMemberReview(createMemberReviewRequest, user.id(), crewId);
 		URI location = UriComponentsBuilder.fromUriString("/api/v1/posts/" + reviewIdResponse.id()).build().toUri();
 		return ResponseEntity.created(location).build();
@@ -66,10 +68,10 @@ public class ReviewController {
 	 */
 	@GetMapping("/reviews/{reviewId}")
 	public ResponseEntity<ApiResponse<ReviewResponse>> getSingleReview
-		(
-			@PathVariable Long reviewId,
-			@AuthenticationPrincipal JwtAuthentication user
-		) {
+	(
+		@PathVariable Long reviewId,
+		@AuthenticationPrincipal JwtAuthentication user
+	) {
 		ReviewResponse findReview = reviewService.getSingleReview(reviewId, user.id());
 		return ResponseEntity.ok().body(new ApiResponse<>(findReview));
 	}

--- a/src/main/java/com/prgrms/mukvengers/domain/review/dto/request/CreateLeaderReviewRequest.java
+++ b/src/main/java/com/prgrms/mukvengers/domain/review/dto/request/CreateLeaderReviewRequest.java
@@ -4,7 +4,7 @@ import javax.validation.constraints.NotNull;
 
 import org.springframework.lang.Nullable;
 
-public record CreateLeaderReviewRequest(@NotNull Long revieweeId, // reviewee : 방장
+public record CreateLeaderReviewRequest(@NotNull Long leaderId, // reviewee : 방장
 										@Nullable String content,
 										@NotNull Integer mannerPoint,
 										@NotNull Integer tastePoint) {

--- a/src/main/java/com/prgrms/mukvengers/domain/review/dto/request/CreateLeaderReviewRequest.java
+++ b/src/main/java/com/prgrms/mukvengers/domain/review/dto/request/CreateLeaderReviewRequest.java
@@ -1,0 +1,11 @@
+package com.prgrms.mukvengers.domain.review.dto.request;
+
+import javax.validation.constraints.NotNull;
+
+import org.springframework.lang.Nullable;
+
+public record CreateLeaderReviewRequest(@NotNull Long revieweeId, // reviewee : 방장
+										@Nullable String content,
+										@NotNull Integer mannerPoint,
+										@NotNull Integer tastePoint) {
+}

--- a/src/main/java/com/prgrms/mukvengers/domain/review/dto/request/CreateMemberReviewRequest.java
+++ b/src/main/java/com/prgrms/mukvengers/domain/review/dto/request/CreateMemberReviewRequest.java
@@ -1,0 +1,10 @@
+package com.prgrms.mukvengers.domain.review.dto.request;
+
+import javax.validation.constraints.NotNull;
+
+import org.springframework.lang.Nullable;
+
+public record CreateMemberReviewRequest(@NotNull Long revieweeId,
+										@Nullable String content,
+										@NotNull Integer mannerPoint) {
+}

--- a/src/main/java/com/prgrms/mukvengers/domain/review/dto/response/ReviewResponse.java
+++ b/src/main/java/com/prgrms/mukvengers/domain/review/dto/response/ReviewResponse.java
@@ -1,0 +1,17 @@
+package com.prgrms.mukvengers.domain.review.dto.response;
+
+import java.time.LocalDateTime;
+
+import com.prgrms.mukvengers.domain.store.dto.response.StoreResponse;
+import com.prgrms.mukvengers.domain.user.dto.response.UserProfileResponse;
+
+public record ReviewResponse(UserProfileResponse reviewer,
+							 UserProfileResponse reviewee,
+							 StoreResponse store,
+							 String crewName,
+							 LocalDateTime promiseTime,
+							 String content,
+							 Integer mannerPoint,
+							 Integer tastePoint
+							 ) {
+}

--- a/src/main/java/com/prgrms/mukvengers/domain/review/mapper/ReviewMapper.java
+++ b/src/main/java/com/prgrms/mukvengers/domain/review/mapper/ReviewMapper.java
@@ -1,0 +1,70 @@
+package com.prgrms.mukvengers.domain.review.mapper;
+
+import static org.mapstruct.ReportingPolicy.*;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.Named;
+
+import com.prgrms.mukvengers.domain.crew.model.Crew;
+import com.prgrms.mukvengers.domain.review.dto.request.CreateLeaderReviewRequest;
+import com.prgrms.mukvengers.domain.review.dto.request.CreateMemberReviewRequest;
+import com.prgrms.mukvengers.domain.review.dto.response.ReviewResponse;
+import com.prgrms.mukvengers.domain.review.model.Review;
+import com.prgrms.mukvengers.domain.user.model.User;
+
+@Mapper(componentModel = "spring", unmappedTargetPolicy = IGNORE)
+public interface ReviewMapper {
+
+	@Mapping(source = "reviewer", target = "reviewer")
+	@Mapping(source = "reviewee", target = "reviewee")
+	@Mapping(source = "crew.store", target = "store")
+	@Mapping(source = "crew.name", target = "crewName")
+	@Mapping(source = "crew.promiseTime", target = "promiseTime")
+	@Mapping(source = "request.content", target = "content")
+	@Mapping(source = "request.mannerPoint", target = "mannerPoint")
+	@Mapping(source = "request.tastePoint", target = "tastePoint")
+	Review toReview(CreateLeaderReviewRequest request, User reviewer, User reviewee, Crew crew);
+
+	@Mapping(source = "reviewer", target = "reviewer")
+	@Mapping(source = "reviewee", target = "reviewee")
+	@Mapping(source = "crew.store", target = "store")
+	@Mapping(source = "crew.name", target = "crewName")
+	@Mapping(source = "crew.promiseTime", target = "promiseTime")
+	@Mapping(source = "request.content", target = "content")
+	@Mapping(source = "request.mannerPoint", target = "mannerPoint")
+	Review toReview(CreateMemberReviewRequest request, User reviewer, User reviewee, Crew crew);
+
+	@Mapping(source = "reviewer", target = "reviewer")
+	@Mapping(source = "reviewee", target = "reviewee")
+	@Mapping(source = "review", target = "store.id", qualifiedByName = "storeIdMethod")
+	@Mapping(source = "review", target = "store.latitude", qualifiedByName = "latitudeMethod")
+	@Mapping(source = "review", target = "store.longitude", qualifiedByName = "longitudeMethod")
+	@Mapping(source = "review", target = "store.mapStoreId", qualifiedByName = "storeMapStoreId")
+	@Mapping(source = "crewName", target = "crewName")
+	@Mapping(source = "promiseTime", target = "promiseTime")
+	@Mapping(source = "content", target = "content")
+	@Mapping(source = "mannerPoint", target = "mannerPoint")
+	@Mapping(source = "tastePoint", target = "tastePoint")
+	ReviewResponse toReviewResponse(Review review);
+
+	@Named("latitudeMethod")
+	default String mapLatitude(Review review) {
+		return String.valueOf(review.getStore().getLocation().getX());
+	}
+
+	@Named("longitudeMethod")
+	default String mapLongitude(Review review) {
+		return String.valueOf(review.getStore().getLocation().getY());
+	}
+
+	@Named("storeIdMethod")
+	default String mapStoreId(Review review) {
+		return String.valueOf(review.getStore().getId());
+	}
+
+	@Named("storeMapStoreId")
+	default String mapStoreMapStoreId(Review review) {
+		return String.valueOf(review.getStore().getId());
+	}
+}

--- a/src/main/java/com/prgrms/mukvengers/domain/review/repository/ReviewRepository.java
+++ b/src/main/java/com/prgrms/mukvengers/domain/review/repository/ReviewRepository.java
@@ -1,0 +1,8 @@
+package com.prgrms.mukvengers.domain.review.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.prgrms.mukvengers.domain.review.model.Review;
+
+public interface ReviewRepository extends JpaRepository<Review, Long> {
+}

--- a/src/main/java/com/prgrms/mukvengers/domain/review/service/ReviewService.java
+++ b/src/main/java/com/prgrms/mukvengers/domain/review/service/ReviewService.java
@@ -1,0 +1,14 @@
+package com.prgrms.mukvengers.domain.review.service;
+
+import com.prgrms.mukvengers.domain.review.dto.request.CreateLeaderReviewRequest;
+import com.prgrms.mukvengers.domain.review.dto.request.CreateMemberReviewRequest;
+import com.prgrms.mukvengers.domain.review.dto.response.ReviewResponse;
+import com.prgrms.mukvengers.global.common.dto.IdResponse;
+
+public interface ReviewService {
+	IdResponse createReviewOfLeader(CreateLeaderReviewRequest request, Long reviewerId, Long crewId);
+
+	IdResponse createMemberReview(CreateMemberReviewRequest request, Long reviewerId, Long crewId);
+
+	ReviewResponse getSingleReview(Long reviewId, Long userId);
+}

--- a/src/main/java/com/prgrms/mukvengers/domain/review/service/ReviewServiceImpl.java
+++ b/src/main/java/com/prgrms/mukvengers/domain/review/service/ReviewServiceImpl.java
@@ -37,7 +37,7 @@ public class ReviewServiceImpl implements ReviewService {
 		User reviewer = userRepository.findById(reviewerId)
 			.orElseThrow(() -> new IllegalArgumentException("해당 Reviewer 존재하지 않는 회원입니다."));
 
-		User reviewee = userRepository.findById(leaderReviewRequest.revieweeId())
+		User reviewee = userRepository.findById(leaderReviewRequest.leaderId())
 			.orElseThrow(() -> new IllegalArgumentException("해당 Reviewee 존재하지 않는 회원입니다."));
 
 		Crew crew = crewRepository.findById(crewId)
@@ -64,7 +64,7 @@ public class ReviewServiceImpl implements ReviewService {
 			.orElseThrow(() -> new IllegalArgumentException("Reviewer 존재하지 않는 사용자이거나 해당 밥모임원이 아닙니다."));
 
 		User reviewee = userRepository.findById(memberReviewRequest.revieweeId())
-			.filter(r -> crewMemberRepository.findCrewMemberByCrewId(crewId, r.getId()).isPresent())
+			.filter(review -> crewMemberRepository.findCrewMemberByCrewId(crewId, review.getId()).isPresent())
 			.orElseThrow(() -> new IllegalArgumentException("Reviewee 존재하지 않는 사용자이거나 해당 밥모임원이 아닙니다."));
 
 		Review review = reviewMapper.toReview(memberReviewRequest, reviewer, reviewee, crew);

--- a/src/main/java/com/prgrms/mukvengers/domain/review/service/ReviewServiceImpl.java
+++ b/src/main/java/com/prgrms/mukvengers/domain/review/service/ReviewServiceImpl.java
@@ -1,0 +1,88 @@
+package com.prgrms.mukvengers.domain.review.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.prgrms.mukvengers.domain.crew.model.Crew;
+import com.prgrms.mukvengers.domain.crew.repository.CrewRepository;
+import com.prgrms.mukvengers.domain.crewmember.repository.CrewMemberRepository;
+import com.prgrms.mukvengers.domain.review.dto.request.CreateLeaderReviewRequest;
+import com.prgrms.mukvengers.domain.review.dto.request.CreateMemberReviewRequest;
+import com.prgrms.mukvengers.domain.review.dto.response.ReviewResponse;
+import com.prgrms.mukvengers.domain.review.mapper.ReviewMapper;
+import com.prgrms.mukvengers.domain.review.model.Review;
+import com.prgrms.mukvengers.domain.review.repository.ReviewRepository;
+import com.prgrms.mukvengers.domain.user.model.User;
+import com.prgrms.mukvengers.domain.user.repository.UserRepository;
+import com.prgrms.mukvengers.global.common.dto.IdResponse;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ReviewServiceImpl implements ReviewService {
+
+	private final UserRepository userRepository;
+	private final CrewRepository crewRepository;
+	private final CrewMemberRepository crewMemberRepository;
+	private final ReviewRepository reviewRepository;
+	private final ReviewMapper reviewMapper;
+
+	@Override
+	@Transactional
+	public IdResponse createReviewOfLeader(CreateLeaderReviewRequest leaderReviewRequest, Long reviewerId,
+		Long crewId) {
+
+		User reviewer = userRepository.findById(reviewerId)
+			.orElseThrow(() -> new IllegalArgumentException("해당 Reviewer 존재하지 않는 회원입니다."));
+
+		User reviewee = userRepository.findById(leaderReviewRequest.revieweeId())
+			.orElseThrow(() -> new IllegalArgumentException("해당 Reviewee 존재하지 않는 회원입니다."));
+
+		Crew crew = crewRepository.findById(crewId)
+			.orElseThrow(() -> new IllegalArgumentException("해당 crew 존재하지 않는 밥모임입니다."));
+
+		Crew findCrew = crewRepository.joinCrewMemberByCrewId(crew.getId(), reviewer.getId(), reviewee.getId())
+			.orElseThrow(() -> new IllegalArgumentException("해당 Reviewer와 Reviewee는 밥모임 아이디가 같지 않다."));
+
+		Review review = reviewMapper.toReview(leaderReviewRequest, reviewer, reviewee, findCrew);
+
+		Review saveReview = reviewRepository.save(review);
+		return new IdResponse(saveReview.getId());
+	}
+
+	@Override
+	@Transactional
+	public IdResponse createMemberReview(CreateMemberReviewRequest memberReviewRequest, Long reviewerId, Long crewId) {
+
+		Crew crew = crewRepository.findById(crewId)
+			.orElseThrow(() -> new IllegalArgumentException("해당 crew는 존재하지 않는 밥모임입니다."));
+
+		User reviewer = userRepository.findById(reviewerId)
+			.filter(r -> crewMemberRepository.findCrewMemberByCrewId(crewId, r.getId()).isPresent())
+			.orElseThrow(() -> new IllegalArgumentException("Reviewer 존재하지 않는 사용자이거나 해당 밥모임원이 아닙니다."));
+
+		User reviewee = userRepository.findById(memberReviewRequest.revieweeId())
+			.filter(r -> crewMemberRepository.findCrewMemberByCrewId(crewId, r.getId()).isPresent())
+			.orElseThrow(() -> new IllegalArgumentException("Reviewee 존재하지 않는 사용자이거나 해당 밥모임원이 아닙니다."));
+
+		Review review = reviewMapper.toReview(memberReviewRequest, reviewer, reviewee, crew);
+
+		Review saveReview = reviewRepository.save(review);
+		return new IdResponse(saveReview.getId());
+	}
+
+	@Override
+	public ReviewResponse getSingleReview(Long reviewId, Long userId) {
+
+		Review review = reviewRepository.findById(reviewId)
+			.orElseThrow(() -> new IllegalArgumentException("해당 리뷰는 존재하지 않는 리뷰입니다."));
+
+		if (!review.getReviewer().isSameUser(userId) && !review.getReviewee().isSameUser(userId)) {
+			throw new IllegalArgumentException("해당 리뷰를 볼 수 있는 접근 권한이 없습니다.");
+		}
+
+		return reviewMapper.toReviewResponse(review);
+	}
+}

--- a/src/test/java/com/prgrms/mukvengers/base/ControllerTest.java
+++ b/src/test/java/com/prgrms/mukvengers/base/ControllerTest.java
@@ -24,6 +24,7 @@ import org.springframework.web.filter.CharacterEncodingFilter;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.prgrms.mukvengers.config.RestDocsConfig;
 import com.prgrms.mukvengers.domain.crew.repository.CrewRepository;
+import com.prgrms.mukvengers.domain.crewmember.repository.CrewMemberRepository;
 import com.prgrms.mukvengers.domain.store.model.Store;
 import com.prgrms.mukvengers.domain.store.repository.StoreRepository;
 import com.prgrms.mukvengers.domain.user.model.User;
@@ -60,6 +61,9 @@ public abstract class ControllerTest {
 
 	@Autowired
 	protected CrewRepository crewRepository;
+
+	@Autowired
+	protected CrewMemberRepository crewMemberRepository;
 
 	protected MockMvc mockMvc;
 

--- a/src/test/java/com/prgrms/mukvengers/base/ControllerTest.java
+++ b/src/test/java/com/prgrms/mukvengers/base/ControllerTest.java
@@ -29,7 +29,6 @@ import com.prgrms.mukvengers.domain.store.repository.StoreRepository;
 import com.prgrms.mukvengers.domain.user.model.User;
 import com.prgrms.mukvengers.domain.user.repository.UserRepository;
 import com.prgrms.mukvengers.global.security.jwt.JwtTokenProvider;
-import com.prgrms.mukvengers.utils.StoreObjectProvider;
 
 @Transactional
 @SpringBootTest
@@ -37,6 +36,10 @@ import com.prgrms.mukvengers.utils.StoreObjectProvider;
 @ExtendWith(RestDocumentationExtension.class)
 @AutoConfigureTestDatabase(replace = NONE)
 public abstract class ControllerTest {
+
+	protected final String CREW = "모임 API";
+	protected final String STORE = "가게 API";
+	protected final String USER = "유저 API";
 
 	protected final String BEARER_TYPE = "Bearer ";
 
@@ -62,7 +65,7 @@ public abstract class ControllerTest {
 
 	protected User savedUser;
 	protected Long savedUserId;
-	protected String ACCESS_TOKEN;
+	protected String accessToken;
 	protected Store savedStore;
 
 	@BeforeEach
@@ -80,7 +83,7 @@ public abstract class ControllerTest {
 	void setUpLogin() {
 		savedUser = userRepository.save(createUser());
 		savedUserId = savedUser.getId();
-		ACCESS_TOKEN = jwtTokenProvider.createAccessToken(savedUserId, "USER");
+		accessToken = jwtTokenProvider.createAccessToken(savedUserId, "USER");
 
 		savedStore = storeRepository.save(createStore());
 	}

--- a/src/test/java/com/prgrms/mukvengers/base/RepositoryTest.java
+++ b/src/test/java/com/prgrms/mukvengers/base/RepositoryTest.java
@@ -14,6 +14,8 @@ import org.springframework.context.annotation.Import;
 
 import com.prgrms.mukvengers.domain.crew.model.Crew;
 import com.prgrms.mukvengers.domain.crew.repository.CrewRepository;
+import com.prgrms.mukvengers.domain.crewmember.repository.CrewMemberRepository;
+import com.prgrms.mukvengers.domain.review.repository.ReviewRepository;
 import com.prgrms.mukvengers.domain.store.model.Store;
 import com.prgrms.mukvengers.domain.store.repository.StoreRepository;
 import com.prgrms.mukvengers.domain.user.model.User;
@@ -34,6 +36,12 @@ public abstract class RepositoryTest {
 
 	@Autowired
 	protected CrewRepository crewRepository;
+
+	@Autowired
+	protected CrewMemberRepository crewMemberRepository;
+
+	@Autowired
+	protected ReviewRepository reviewRepository;
 
 	protected User savedUser;
 

--- a/src/test/java/com/prgrms/mukvengers/base/ServiceTest.java
+++ b/src/test/java/com/prgrms/mukvengers/base/ServiceTest.java
@@ -11,6 +11,8 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.prgrms.mukvengers.domain.crew.repository.CrewRepository;
 import com.prgrms.mukvengers.domain.crew.service.CrewService;
+import com.prgrms.mukvengers.domain.review.repository.ReviewRepository;
+import com.prgrms.mukvengers.domain.review.service.ReviewService;
 import com.prgrms.mukvengers.domain.store.model.Store;
 import com.prgrms.mukvengers.domain.store.repository.StoreRepository;
 import com.prgrms.mukvengers.domain.store.service.StoreService;
@@ -35,6 +37,12 @@ public abstract class ServiceTest {
 
 	@Autowired
 	protected CrewService crewService;
+
+	@Autowired
+	protected ReviewService reviewService;
+
+	@Autowired
+	protected ReviewRepository reviewRepository;
 
 	protected GeometryFactory gf = new GeometryFactory();
 

--- a/src/test/java/com/prgrms/mukvengers/domain/crew/api/CrewControllerTest.java
+++ b/src/test/java/com/prgrms/mukvengers/domain/crew/api/CrewControllerTest.java
@@ -1,13 +1,14 @@
 package com.prgrms.mukvengers.domain.crew.api;
 
 import static com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper.*;
+import static com.epages.restdocs.apispec.ResourceDocumentation.*;
 import static com.epages.restdocs.apispec.ResourceSnippetParameters.*;
 import static org.hamcrest.Matchers.*;
+import static org.springframework.http.HttpHeaders.*;
 import static org.springframework.http.MediaType.*;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;
 import static org.springframework.restdocs.payload.JsonFieldType.*;
 import static org.springframework.restdocs.payload.PayloadDocumentation.*;
-import static org.springframework.restdocs.request.RequestDocumentation.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
@@ -15,10 +16,10 @@ import java.util.List;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.http.HttpHeaders;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 
+import com.epages.restdocs.apispec.Schema;
 import com.prgrms.mukvengers.base.ControllerTest;
 import com.prgrms.mukvengers.domain.crew.dto.request.CreateCrewRequest;
 import com.prgrms.mukvengers.domain.crew.dto.request.UpdateStatusRequest;
@@ -26,6 +27,12 @@ import com.prgrms.mukvengers.domain.crew.model.Crew;
 import com.prgrms.mukvengers.utils.CrewObjectProvider;
 
 class CrewControllerTest extends ControllerTest {
+
+	public static final Schema CREATE_CREW_REQUEST = new Schema("createCrewRequest");
+	public static final Schema CREW_PAGE_RESPONSE = new Schema("crewPageResponse");
+	public static final Schema FIND_BY_USER_LOCATION_CREW_REQUEST = new Schema("findByUserLocationCrewRequest");
+	public static final Schema CREW_RESPONSE = new Schema("crewResponse");
+	public static final Schema UPDATE_CREW_REQUEST = new Schema("updateCrewRequest");
 
 	@Test
 	@DisplayName("[성공]밥 모임을 저장한다.")
@@ -37,27 +44,33 @@ class CrewControllerTest extends ControllerTest {
 
 		mockMvc.perform(post("/api/v1/crews")
 				.contentType(APPLICATION_JSON)
-				.header(HttpHeaders.AUTHORIZATION, BEARER_TYPE + ACCESS_TOKEN)
+				.header(AUTHORIZATION, BEARER_TYPE + accessToken)
 				.content(jsonRequest))
 			.andExpect(status().isCreated())
 			.andExpect(header().string("Location", containsString("/api/v1/crews")))
 			.andExpect(redirectedUrlPattern("http://localhost:8080/api/v1/crews/*"))
 			.andDo(print())
-			.andDo(document("crew-create",
-				builder()
-					.tag("crew")
-					.description("모임을 생성합니다.")
-					.requestFields(
-						fieldWithPath("latitude").type(STRING).description("위도"),
-						fieldWithPath("longitude").type(STRING).description("경도"),
-						fieldWithPath("mapStoreId").type(STRING).description("지도 api 제공 id"),
-						fieldWithPath("name").type(STRING).description("밥 모임 이름"),
-						fieldWithPath("capacity").type(NUMBER).description("밥 모임 정원"),
-						fieldWithPath("promiseTime").type(STRING).description("약속 시간"),
-						fieldWithPath("status").type(STRING).description("밥 모임 상태"),
-						fieldWithPath("content").type(STRING).description("밥 모임 설명"),
-						fieldWithPath("category").type(STRING).description("밥 모임 카테고리")
-					)
+			.andDo(document("모임 생성",
+				resource(
+					builder()
+						.tag(CREW)
+						.summary("모임 생성 API")
+						.description("모임을 생성합니다.")
+						.requestSchema(CREATE_CREW_REQUEST)
+						.requestFields(
+							fieldWithPath("latitude").type(STRING).description("위도"),
+							fieldWithPath("longitude").type(STRING).description("경도"),
+							fieldWithPath("mapStoreId").type(STRING).description("지도 api 제공 id"),
+							fieldWithPath("name").type(STRING).description("밥 모임 이름"),
+							fieldWithPath("capacity").type(NUMBER).description("밥 모임 정원"),
+							fieldWithPath("promiseTime").type(STRING).description("약속 시간"),
+							fieldWithPath("status").type(STRING).description("밥 모임 상태"),
+							fieldWithPath("content").type(STRING).description("밥 모임 설명"),
+							fieldWithPath("category").type(STRING).description("밥 모임 카테고리"))
+						.responseHeaders(
+							headerWithName("Location").description("조회해볼 수 있는 요청 주소"))
+						.build()
+				)
 			));
 
 	}
@@ -80,64 +93,79 @@ class CrewControllerTest extends ControllerTest {
 
 		mockMvc.perform(get("/api/v1/crews/{mapStoreId}", savedStore.getMapStoreId())
 				.params(params)
-				.header(HttpHeaders.AUTHORIZATION, BEARER_TYPE + ACCESS_TOKEN)
+				.header(AUTHORIZATION, BEARER_TYPE + accessToken)
 				.accept(APPLICATION_JSON))
 			.andExpect(status().isOk())
 			.andExpect(jsonPath("$.data").exists())
 			.andDo(print())
 			.andDo(document("crew-findByMapStoreId",
-				builder()
-					.tag("crew")
-					.description("맵 api 아이디로 밥 모임을 조회합니다.")
-					.pathParameters(
-						parameterWithName("mapStoreId").description("api에서 사용하는 가게 아이디")
-					),
-				requestParameters(
-					parameterWithName("page").description("현제 페이지 번호"),
-					parameterWithName("size").description("한번에 가져올 데이터 사이즈")),
-				responseFields(
-					fieldWithPath("data.responses.content.[].id").type(NUMBER).description("밥 모임 아이디"),
-					fieldWithPath("data.responses.content.[].leader").type(OBJECT).description("밥 모임 방장 정보"),
-					fieldWithPath("data.responses.content.[].leader.id").type(NUMBER).description("방장 아이디"),
-					fieldWithPath("data.responses.content.[].leader.nickname").type(STRING).description("방장 닉네임"),
-					fieldWithPath("data.responses.content.[].leader.profileImgUrl").type(STRING).description("방장 프로필"),
-					fieldWithPath("data.responses.content.[].leader.introduction").type(STRING).description("방장 소개"),
-					fieldWithPath("data.responses.content.[].leader.leaderCount").type(NUMBER).description("방장 횟수"),
-					fieldWithPath("data.responses.content.[].leader.crewCount").type(NUMBER).description("방장 모임 참여 횟수"),
-					fieldWithPath("data.responses.content.[].leader.tasteScore").type(NUMBER).description("방장 맛잘알 점수"),
-					fieldWithPath("data.responses.content.[].leader.mannerScore").type(NUMBER).description("방장 매너온도"),
-					fieldWithPath("data.responses.content.[].store").type(OBJECT).description("밥 모임 가게 정보"),
-					fieldWithPath("data.responses.content.[].store.id").type(NUMBER).description("밥 모임 가게 아이디"),
-					fieldWithPath("data.responses.content.[].store.latitude").type(STRING).description("밥 모임 가게 위도"),
-					fieldWithPath("data.responses.content.[].store.longitude").type(STRING).description("밥 모임 가게 경도"),
-					fieldWithPath("data.responses.content.[].store.mapStoreId").type(STRING).description("맵 api 아이디"),
-					fieldWithPath("data.responses.content.[].name").type(STRING).description("밥 모임 이름"),
-					fieldWithPath("data.responses.content.[].latitude").type(STRING).description("가게 위도"),
-					fieldWithPath("data.responses.content.[].longitude").type(STRING).description("가게 경도"),
-					fieldWithPath("data.responses.content.[].capacity").type(NUMBER).description("밥 모임 정원"),
-					fieldWithPath("data.responses.content.[].promiseTime").type(ARRAY).description("약속 시간"),
-					fieldWithPath("data.responses.content.[].status").type(STRING).description("밥 모임 상태"),
-					fieldWithPath("data.responses.content.[].content").type(STRING).description("밥 모임 내용"),
-					fieldWithPath("data.responses.content.[].category").type(STRING).description("밥 모임 카테고리"),
-					fieldWithPath("data.responses.pageable.sort.empty").type(BOOLEAN).description("빈 페이지 여부"),
-					fieldWithPath("data.responses.pageable.sort.sorted").type(BOOLEAN).description("페이지 정렬 여부"),
-					fieldWithPath("data.responses.pageable.sort.unsorted").type(BOOLEAN).description("페이지 비정렬 여부"),
-					fieldWithPath("data.responses.pageable.offset").type(NUMBER).description("페이지 오프셋"),
-					fieldWithPath("data.responses.pageable.pageNumber").type(NUMBER).description("페이지 번호"),
-					fieldWithPath("data.responses.pageable.pageSize").type(NUMBER).description("한 페이지에 나타내는 원소 수"),
-					fieldWithPath("data.responses.pageable.paged").type(BOOLEAN).description("페이지 정보 포함 여부"),
-					fieldWithPath("data.responses.pageable.unpaged").type(BOOLEAN).description("페이지 정보 비포함 여부"),
-					fieldWithPath("data.responses.last").type(BOOLEAN).description("마지막 페이지 여부"),
-					fieldWithPath("data.responses.size").type(NUMBER).description("페이지 사이즈"),
-					fieldWithPath("data.responses.number").type(NUMBER).description("페이지 번호"),
-					fieldWithPath("data.responses.sort.empty").type(BOOLEAN).description("빈 페이지 여부"),
-					fieldWithPath("data.responses.sort.sorted").type(BOOLEAN).description("페이지 정렬 여부"),
-					fieldWithPath("data.responses.sort.unsorted").type(BOOLEAN).description("페이지 비정렬 여부"),
-					fieldWithPath("data.responses.first").type(BOOLEAN).description("첫 번째 페이지 여부"),
-					fieldWithPath("data.responses.numberOfElements").type(NUMBER).description("페이지 원소 개수"),
-					fieldWithPath("data.responses.empty").type(BOOLEAN).description("빈 페이지 여부"),
-					fieldWithPath("data.responses.totalPages").type(NUMBER).description("전체 페이지 개수"),
-					fieldWithPath("data.responses.totalElements").type(NUMBER).description("전체 데이터 개수")
+				resource(
+					builder()
+						.tag(CREW)
+						.summary("가게 기반 밥 모임 조회 API")
+						.description("맵 api 아이디로 밥 모임을 조회합니다.")
+						.pathParameters(
+							parameterWithName("mapStoreId").description("api에서 사용하는 가게 아이디"))
+						.requestParameters(
+							parameterWithName("page").description("현재 페이지 번호"),
+							parameterWithName("size").description("한번에 가져올 데이터 사이즈"))
+						.responseSchema(CREW_PAGE_RESPONSE)
+						.responseFields(
+							fieldWithPath("data.responses.content.[].id").type(NUMBER).description("밥 모임 아이디"),
+							fieldWithPath("data.responses.content.[].leader").type(OBJECT).description("밥 모임 방장 정보"),
+							fieldWithPath("data.responses.content.[].leader.id").type(NUMBER).description("방장 아이디"),
+							fieldWithPath("data.responses.content.[].leader.nickname").type(STRING)
+								.description("방장 닉네임"),
+							fieldWithPath("data.responses.content.[].leader.profileImgUrl").type(STRING)
+								.description("방장 프로필"),
+							fieldWithPath("data.responses.content.[].leader.introduction").type(STRING)
+								.description("방장 소개"),
+							fieldWithPath("data.responses.content.[].leader.leaderCount").type(NUMBER)
+								.description("방장 횟수"),
+							fieldWithPath("data.responses.content.[].leader.crewCount").type(NUMBER)
+								.description("방장 모임 참여 횟수"),
+							fieldWithPath("data.responses.content.[].leader.tasteScore").type(NUMBER)
+								.description("방장 맛잘알 점수"),
+							fieldWithPath("data.responses.content.[].leader.mannerScore").type(NUMBER)
+								.description("방장 매너온도"),
+							fieldWithPath("data.responses.content.[].store").type(OBJECT).description("밥 모임 가게 정보"),
+							fieldWithPath("data.responses.content.[].store.id").type(NUMBER).description("밥 모임 가게 아이디"),
+							fieldWithPath("data.responses.content.[].store.latitude").type(STRING)
+								.description("밥 모임 가게 위도"),
+							fieldWithPath("data.responses.content.[].store.longitude").type(STRING)
+								.description("밥 모임 가게 경도"),
+							fieldWithPath("data.responses.content.[].store.mapStoreId").type(STRING)
+								.description("맵 api 아이디"),
+							fieldWithPath("data.responses.content.[].name").type(STRING).description("밥 모임 이름"),
+							fieldWithPath("data.responses.content.[].latitude").type(STRING).description("가게 위도"),
+							fieldWithPath("data.responses.content.[].longitude").type(STRING).description("가게 경도"),
+							fieldWithPath("data.responses.content.[].capacity").type(NUMBER).description("밥 모임 정원"),
+							fieldWithPath("data.responses.content.[].promiseTime").type(ARRAY).description("약속 시간"),
+							fieldWithPath("data.responses.content.[].status").type(STRING).description("밥 모임 상태"),
+							fieldWithPath("data.responses.content.[].content").type(STRING).description("밥 모임 내용"),
+							fieldWithPath("data.responses.content.[].category").type(STRING).description("밥 모임 카테고리"),
+							fieldWithPath("data.responses.pageable.sort.empty").type(BOOLEAN).description("빈 페이지 여부"),
+							fieldWithPath("data.responses.pageable.sort.sorted").type(BOOLEAN).description("페이지 정렬 여부"),
+							fieldWithPath("data.responses.pageable.sort.unsorted").type(BOOLEAN)
+								.description("페이지 비정렬 여부"),
+							fieldWithPath("data.responses.pageable.offset").type(NUMBER).description("페이지 오프셋"),
+							fieldWithPath("data.responses.pageable.pageNumber").type(NUMBER).description("페이지 번호"),
+							fieldWithPath("data.responses.pageable.pageSize").type(NUMBER)
+								.description("한 페이지에 나타내는 원소 수"),
+							fieldWithPath("data.responses.pageable.paged").type(BOOLEAN).description("페이지 정보 포함 여부"),
+							fieldWithPath("data.responses.pageable.unpaged").type(BOOLEAN).description("페이지 정보 비포함 여부"),
+							fieldWithPath("data.responses.last").type(BOOLEAN).description("마지막 페이지 여부"),
+							fieldWithPath("data.responses.size").type(NUMBER).description("페이지 사이즈"),
+							fieldWithPath("data.responses.number").type(NUMBER).description("페이지 번호"),
+							fieldWithPath("data.responses.sort.empty").type(BOOLEAN).description("빈 페이지 여부"),
+							fieldWithPath("data.responses.sort.sorted").type(BOOLEAN).description("페이지 정렬 여부"),
+							fieldWithPath("data.responses.sort.unsorted").type(BOOLEAN).description("페이지 비정렬 여부"),
+							fieldWithPath("data.responses.first").type(BOOLEAN).description("첫 번째 페이지 여부"),
+							fieldWithPath("data.responses.numberOfElements").type(NUMBER).description("페이지 원소 개수"),
+							fieldWithPath("data.responses.empty").type(BOOLEAN).description("빈 페이지 여부"),
+							fieldWithPath("data.responses.totalPages").type(NUMBER).description("전체 페이지 개수"),
+							fieldWithPath("data.responses.totalElements").type(NUMBER).description("전체 데이터 개수"))
+						.build()
 				)
 			));
 
@@ -160,42 +188,47 @@ class CrewControllerTest extends ControllerTest {
 
 		mockMvc.perform(get("/api/v1/crews")
 				.params(params)
-				.header(HttpHeaders.AUTHORIZATION, BEARER_TYPE + ACCESS_TOKEN)
+				.header(AUTHORIZATION, BEARER_TYPE + accessToken)
 				.accept(APPLICATION_JSON))
 			.andExpect(status().isOk())
 			.andExpect(jsonPath("$.data").exists())
 			.andDo(print())
 			.andDo(document("crew-findByLocation",
-				builder()
-					.tag("crew")
-					.description("사용자 위치로 특정 거리 안에 있는 모임을 조회합니다.")
-					.requestParameters(
-						parameterWithName("latitude").description("사용자의 위도"),
-						parameterWithName("longitude").description("가게 경도")),
-				responseFields(
-					fieldWithPath("data.responses.[].id").type(NUMBER).description("밥 모임 아이디"),
-					fieldWithPath("data.responses.[].leader").type(OBJECT).description("밥 모임 방장 정보"),
-					fieldWithPath("data.responses.[].leader.id").type(NUMBER).description("방장 아이디"),
-					fieldWithPath("data.responses.[].leader.nickname").type(STRING).description("방장 닉네임"),
-					fieldWithPath("data.responses.[].leader.profileImgUrl").type(STRING).description("방장 프로필"),
-					fieldWithPath("data.responses.[].leader.introduction").type(STRING).description("방장 소개"),
-					fieldWithPath("data.responses.[].leader.leaderCount").type(NUMBER).description("방장 횟수"),
-					fieldWithPath("data.responses.[].leader.crewCount").type(NUMBER).description("방장 모임 참여 횟수"),
-					fieldWithPath("data.responses.[].leader.tasteScore").type(NUMBER).description("방장 맛잘알 점수"),
-					fieldWithPath("data.responses.[].leader.mannerScore").type(NUMBER).description("방장 매너온도"),
-					fieldWithPath("data.responses.[].store").type(OBJECT).description("밥 모임 가게 정보"),
-					fieldWithPath("data.responses.[].store.id").type(NUMBER).description("밥 모임 가게 아이디"),
-					fieldWithPath("data.responses.[].store.latitude").type(STRING).description("밥 모임 가게 위도"),
-					fieldWithPath("data.responses.[].store.longitude").type(STRING).description("밥 모임 가게 경도"),
-					fieldWithPath("data.responses.[].store.mapStoreId").type(STRING).description("맵 api 아이디"),
-					fieldWithPath("data.responses.[].name").type(STRING).description("밥 모임 이름"),
-					fieldWithPath("data.responses.[].latitude").type(STRING).description("가게 위도"),
-					fieldWithPath("data.responses.[].longitude").type(STRING).description("가게 경도"),
-					fieldWithPath("data.responses.[].capacity").type(NUMBER).description("밥 모임 정원"),
-					fieldWithPath("data.responses.[].promiseTime").type(ARRAY).description("약속 시간"),
-					fieldWithPath("data.responses.[].status").type(STRING).description("밥 모임 상태"),
-					fieldWithPath("data.responses.[].content").type(STRING).description("밥 모임 내용"),
-					fieldWithPath("data.responses.[].category").type(STRING).description("밥 모임 카테고리")
+				resource(
+					builder()
+						.tag(CREW)
+						.summary("위치 기반 밥 모임 조회 API")
+						.description("사용자 위치로 특정 거리 안에 있는 모임을 조회합니다.")
+						.requestSchema(FIND_BY_USER_LOCATION_CREW_REQUEST)
+						.requestParameters(
+							parameterWithName("latitude").description("사용자의 위도"),
+							parameterWithName("longitude").description("사용자의 경도"))
+						.responseSchema(CREW_RESPONSE)
+						.responseFields(
+							fieldWithPath("data.responses.[].id").type(NUMBER).description("밥 모임 아이디"),
+							fieldWithPath("data.responses.[].leader").type(OBJECT).description("밥 모임 방장 정보"),
+							fieldWithPath("data.responses.[].leader.id").type(NUMBER).description("방장 아이디"),
+							fieldWithPath("data.responses.[].leader.nickname").type(STRING).description("방장 닉네임"),
+							fieldWithPath("data.responses.[].leader.profileImgUrl").type(STRING).description("방장 프로필"),
+							fieldWithPath("data.responses.[].leader.introduction").type(STRING).description("방장 소개"),
+							fieldWithPath("data.responses.[].leader.leaderCount").type(NUMBER).description("방장 횟수"),
+							fieldWithPath("data.responses.[].leader.crewCount").type(NUMBER).description("방장 모임 참여 횟수"),
+							fieldWithPath("data.responses.[].leader.tasteScore").type(NUMBER).description("방장 맛잘알 점수"),
+							fieldWithPath("data.responses.[].leader.mannerScore").type(NUMBER).description("방장 매너온도"),
+							fieldWithPath("data.responses.[].store").type(OBJECT).description("밥 모임 가게 정보"),
+							fieldWithPath("data.responses.[].store.id").type(NUMBER).description("밥 모임 가게 아이디"),
+							fieldWithPath("data.responses.[].store.latitude").type(STRING).description("밥 모임 가게 위도"),
+							fieldWithPath("data.responses.[].store.longitude").type(STRING).description("밥 모임 가게 경도"),
+							fieldWithPath("data.responses.[].store.mapStoreId").type(STRING).description("맵 api 아이디"),
+							fieldWithPath("data.responses.[].name").type(STRING).description("밥 모임 이름"),
+							fieldWithPath("data.responses.[].latitude").type(STRING).description("가게 위도"),
+							fieldWithPath("data.responses.[].longitude").type(STRING).description("가게 경도"),
+							fieldWithPath("data.responses.[].capacity").type(NUMBER).description("밥 모임 정원"),
+							fieldWithPath("data.responses.[].promiseTime").type(ARRAY).description("약속 시간"),
+							fieldWithPath("data.responses.[].status").type(STRING).description("밥 모임 상태"),
+							fieldWithPath("data.responses.[].content").type(STRING).description("밥 모임 내용"),
+							fieldWithPath("data.responses.[].category").type(STRING).description("밥 모임 카테고리"))
+						.build()
 				)
 			));
 	}
@@ -216,18 +249,22 @@ class CrewControllerTest extends ControllerTest {
 
 		mockMvc.perform(patch("/api/v1/crews")
 				.contentType(APPLICATION_JSON)
-				.header(HttpHeaders.AUTHORIZATION, BEARER_TYPE + ACCESS_TOKEN)
+				.header(AUTHORIZATION, BEARER_TYPE + accessToken)
 				.content(jsonRequest))
 			.andExpect(status().isOk())
 			.andDo(print())
 			.andDo(document("crew-updateStatus",
-				builder()
-					.tag("crew")
-					.description("밥 모임의 상태를 변경합니다.")
-					.requestFields(
-						fieldWithPath("crewId").type(NUMBER).description("밥 모임 아이디"),
-						fieldWithPath("status").type(STRING).description("밥 모임 상태")
-					)
+				resource(
+					builder()
+						.tag(CREW)
+						.summary("모임 상태 변경 API")
+						.description("밥 모임의 상태를 변경합니다.")
+						.requestSchema(UPDATE_CREW_REQUEST)
+						.requestFields(
+							fieldWithPath("crewId").type(NUMBER).description("밥 모임 아이디"),
+							fieldWithPath("status").type(STRING).description("밥 모임 상태"))
+						.build()
+				)
 			));
 
 	}

--- a/src/test/java/com/prgrms/mukvengers/domain/crewmember/repository/CrewMemberRepositoryTest.java
+++ b/src/test/java/com/prgrms/mukvengers/domain/crewmember/repository/CrewMemberRepositoryTest.java
@@ -48,6 +48,8 @@ class CrewMemberRepositoryTest extends RepositoryTest {
 			reviewer.getId(),
 			reviewee.getId());
 
+
+		assertThat(findcrew).isPresent();
 		assertThat(findcrew.get().getId()).isEqualTo(crew.getId());
 	}
 }

--- a/src/test/java/com/prgrms/mukvengers/domain/crewmember/repository/CrewMemberRepositoryTest.java
+++ b/src/test/java/com/prgrms/mukvengers/domain/crewmember/repository/CrewMemberRepositoryTest.java
@@ -44,12 +44,9 @@ class CrewMemberRepositoryTest extends RepositoryTest {
 	@DisplayName("[성공] Reviewer와 Reviewee는 밥모임 아이디가 같아야한다.")
 	void joinCrewMemberByCrewId_success() {
 
-		if (crewMember.getCrew().getId().equals(crew.getId()) ) {
-
-		}
-			Optional<Crew> findcrew = crewRepository.joinCrewMemberByCrewId(crew.getId(),
-				reviewer.getId(),
-				reviewee.getId());
+		Optional<Crew> findcrew = crewRepository.joinCrewMemberByCrewId(crew.getId(),
+			reviewer.getId(),
+			reviewee.getId());
 
 		assertThat(findcrew.get().getId()).isEqualTo(crew.getId());
 	}

--- a/src/test/java/com/prgrms/mukvengers/domain/crewmember/repository/CrewMemberRepositoryTest.java
+++ b/src/test/java/com/prgrms/mukvengers/domain/crewmember/repository/CrewMemberRepositoryTest.java
@@ -1,0 +1,56 @@
+package com.prgrms.mukvengers.domain.crewmember.repository;
+
+import static com.prgrms.mukvengers.utils.CrewObjectProvider.*;
+import static com.prgrms.mukvengers.utils.UserObjectProvider.*;
+import static org.assertj.core.api.Assertions.*;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import com.prgrms.mukvengers.base.RepositoryTest;
+import com.prgrms.mukvengers.domain.crew.model.Crew;
+import com.prgrms.mukvengers.domain.crewmember.model.CrewMember;
+import com.prgrms.mukvengers.domain.user.model.User;
+
+class CrewMemberRepositoryTest extends RepositoryTest {
+
+	User reviewer;
+	User reviewee;
+	Crew crew;
+	CrewMember crewMember;
+
+	@BeforeEach
+	void setCrewMember() {
+		reviewer = userRepository.save(createUser());
+		reviewee = userRepository.save(createUser());
+
+		crew = crewRepository.save(createCrew(reviewee, savedStore));
+
+		// CrewMemberObjectProvider
+		CrewMember createCrewMember = CrewMember.builder()
+			.user(reviewer)
+			.crew(crew)
+			.blocked(false)
+			.ready(false)
+			.build();
+
+		crewMember = crewMemberRepository.save(createCrewMember);
+	}
+
+	@Test
+	@DisplayName("[성공] Reviewer와 Reviewee는 밥모임 아이디가 같아야한다.")
+	void joinCrewMemberByCrewId_success() {
+
+		if (crewMember.getCrew().getId().equals(crew.getId()) ) {
+
+		}
+			Optional<Crew> findcrew = crewRepository.joinCrewMemberByCrewId(crew.getId(),
+				reviewer.getId(),
+				reviewee.getId());
+
+		assertThat(findcrew.get().getId()).isEqualTo(crew.getId());
+	}
+}

--- a/src/test/java/com/prgrms/mukvengers/domain/review/api/ReviewControllerTest.java
+++ b/src/test/java/com/prgrms/mukvengers/domain/review/api/ReviewControllerTest.java
@@ -1,12 +1,12 @@
 package com.prgrms.mukvengers.domain.review.api;
 
+import static com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper.*;
 import static com.epages.restdocs.apispec.ResourceDocumentation.*;
 import static com.epages.restdocs.apispec.ResourceSnippetParameters.*;
 import static com.prgrms.mukvengers.utils.CrewObjectProvider.*;
 import static com.prgrms.mukvengers.utils.ReviewObjectProvider.*;
 import static com.prgrms.mukvengers.utils.UserObjectProvider.*;
 import static org.springframework.http.MediaType.*;
-import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.*;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;
 import static org.springframework.restdocs.payload.JsonFieldType.*;
 import static org.springframework.restdocs.payload.PayloadDocumentation.*;
@@ -79,8 +79,9 @@ class ReviewControllerTest extends ControllerTest {
 				resource(
 					builder()
 						.tag(REVIEW)
+						.summary("방장에 대한 리뷰 생성")
 						.requestFields(
-							fieldWithPath("revieweeId").description("방장의 아이디"),
+							fieldWithPath("leaderId").description("방장의 아이디"),
 							fieldWithPath("content").description("추가로 작성하고 싶은 내용"),
 							fieldWithPath("mannerPoint").description("방장에 대한 매너 온도"),
 							fieldWithPath("tastePoint").description("방장에 대한 맛잘알 점수"))
@@ -107,6 +108,7 @@ class ReviewControllerTest extends ControllerTest {
 				resource(
 					builder()
 						.tag(REVIEW)
+						.summary("방장이 아닌 밥모임원에 대한 리뷰 생성")
 						.requestFields(
 							fieldWithPath("revieweeId").description("리뷰이 아이디"),
 							fieldWithPath("content").description("추가로 작성하고 싶은 내용"),
@@ -130,36 +132,42 @@ class ReviewControllerTest extends ControllerTest {
 			.andExpect(status().isOk())
 			.andDo(print())
 			.andDo(document("singleReview",
-				responseFields(
-					fieldWithPath("data.reviewer.id").description("리뷰어의 아이디"),
-					fieldWithPath("data.reviewer.nickname").description("리뷰어의 닉네임"),
-					fieldWithPath("data.reviewer.profileImgUrl").description("리뷰어의 프로필 이미지 주소"),
-					fieldWithPath("data.reviewer.introduction").description("리뷰어의 한줄 소개"),
-					fieldWithPath("data.reviewer.leaderCount").description("리뷰어의 리더 횟수"),
-					fieldWithPath("data.reviewer.crewCount").description("리뷰어의 밥모임 참여한 카운트"),
-					fieldWithPath("data.reviewer.tasteScore").description("리뷰어의 맛잘알 점수"),
-					fieldWithPath("data.reviewer.mannerScore").description("리뷰어의 매너 점수"),
+				resource(
+					builder()
+						.tag(REVIEW)
+						.summary("리뷰 단건 조회")
+						.responseFields(
+							fieldWithPath("data.reviewer.id").description("리뷰어의 아이디"),
+							fieldWithPath("data.reviewer.nickname").description("리뷰어의 닉네임"),
+							fieldWithPath("data.reviewer.profileImgUrl").description("리뷰어의 프로필 이미지 주소"),
+							fieldWithPath("data.reviewer.introduction").description("리뷰어의 한줄 소개"),
+							fieldWithPath("data.reviewer.leaderCount").description("리뷰어의 리더 횟수"),
+							fieldWithPath("data.reviewer.crewCount").description("리뷰어의 밥모임 참여한 카운트"),
+							fieldWithPath("data.reviewer.tasteScore").description("리뷰어의 맛잘알 점수"),
+							fieldWithPath("data.reviewer.mannerScore").description("리뷰어의 매너 점수"),
 
-					fieldWithPath("data.reviewee.id").type(NUMBER).description("리뷰이의 아이디"),
-					fieldWithPath("data.reviewee.nickname").type(STRING).description("리뷰이의 닉네임"),
-					fieldWithPath("data.reviewee.profileImgUrl").type(STRING).description("리뷰이의 프로필 이미지 주소"),
-					fieldWithPath("data.reviewee.introduction").type(STRING).description("리뷰이의 한줄 소개"),
-					fieldWithPath("data.reviewee.leaderCount").type(NUMBER).description("리뷰이의 리더 횟수"),
-					fieldWithPath("data.reviewee.crewCount").type(NUMBER).description("리뷰이의 밥모임 참여한 횟수"),
-					fieldWithPath("data.reviewee.tasteScore").type(NUMBER).description("리뷰이의 맛잘알 점수"),
-					fieldWithPath("data.reviewee.mannerScore").type(NUMBER).description("리뷰이의 매너 점수"),
+							fieldWithPath("data.reviewee.id").type(NUMBER).description("리뷰이의 아이디"),
+							fieldWithPath("data.reviewee.nickname").type(STRING).description("리뷰이의 닉네임"),
+							fieldWithPath("data.reviewee.profileImgUrl").type(STRING).description("리뷰이의 프로필 이미지 주소"),
+							fieldWithPath("data.reviewee.introduction").type(STRING).description("리뷰이의 한줄 소개"),
+							fieldWithPath("data.reviewee.leaderCount").type(NUMBER).description("리뷰이의 리더 횟수"),
+							fieldWithPath("data.reviewee.crewCount").type(NUMBER).description("리뷰이의 밥모임 참여한 횟수"),
+							fieldWithPath("data.reviewee.tasteScore").type(NUMBER).description("리뷰이의 맛잘알 점수"),
+							fieldWithPath("data.reviewee.mannerScore").type(NUMBER).description("리뷰이의 매너 점수"),
 
-					fieldWithPath("data.store.id").type(NUMBER).description("가게의 아이디"),
-					fieldWithPath("data.store.latitude").type(STRING).description("가게의 위도"),
-					fieldWithPath("data.store.longitude").type(STRING).description("가게의 경도"),
-					fieldWithPath("data.store.mapStoreId").type(STRING).description("지도 api 제공 id"),
+							fieldWithPath("data.store.id").type(NUMBER).description("가게의 아이디"),
+							fieldWithPath("data.store.latitude").type(STRING).description("가게의 위도"),
+							fieldWithPath("data.store.longitude").type(STRING).description("가게의 경도"),
+							fieldWithPath("data.store.mapStoreId").type(STRING).description("지도 api 제공 id"),
 
-					fieldWithPath("data.crewName").type(STRING).description("리뷰하고자 하는 밥모임 이름"),
-					fieldWithPath("data.promiseTime").type(ARRAY).description("리뷰하고자 하는 밥모임 약속 시간"),
-					fieldWithPath("data.content").type(STRING).description("리뷰하고자 하는 밥모임 간단 한줄 리뷰 "),
-					fieldWithPath("data.mannerPoint").type(NUMBER).description("리뷰하고자 하는 밥모임 매너 온도"),
-					fieldWithPath("data.tastePoint").type(NUMBER).description("리뷰하고자 하는 밥모임 맛잘알 점수")
-					)
+							fieldWithPath("data.crewName").type(STRING).description("리뷰하고자 하는 밥모임 이름"),
+							fieldWithPath("data.promiseTime").type(ARRAY).description("리뷰하고자 하는 밥모임 약속 시간"),
+							fieldWithPath("data.content").type(STRING).description("리뷰하고자 하는 밥모임 간단 한줄 리뷰 "),
+							fieldWithPath("data.mannerPoint").type(NUMBER).description("리뷰하고자 하는 밥모임 매너 온도"),
+							fieldWithPath("data.tastePoint").type(NUMBER).description("리뷰하고자 하는 밥모임 맛잘알 점수")
+						)
+						.build()
+				)
 			));
 	}
 

--- a/src/test/java/com/prgrms/mukvengers/domain/review/api/ReviewControllerTest.java
+++ b/src/test/java/com/prgrms/mukvengers/domain/review/api/ReviewControllerTest.java
@@ -71,7 +71,7 @@ class ReviewControllerTest extends ControllerTest {
 		String jsonRequest = objectMapper.writeValueAsString(leaderReviewRequest);
 
 		mockMvc.perform(post("/api/v1/crews/{crewId}/reviews/leader", crew.getId())
-				.header(HttpHeaders.AUTHORIZATION, BEARER_TYPE + ACCESS_TOKEN)
+				.header(HttpHeaders.AUTHORIZATION, BEARER_TYPE + accessToken)
 				.contentType(APPLICATION_JSON)
 				.content(jsonRequest))
 			.andExpect(status().isCreated())
@@ -100,7 +100,7 @@ class ReviewControllerTest extends ControllerTest {
 		String jsonRequest = objectMapper.writeValueAsString(memberReviewRequest);
 
 		mockMvc.perform(post("/api/v1/crews/{crewId}/reviews/member", crew.getId())
-				.header(HttpHeaders.AUTHORIZATION, BEARER_TYPE + ACCESS_TOKEN)
+				.header(HttpHeaders.AUTHORIZATION, BEARER_TYPE + accessToken)
 				.contentType(APPLICATION_JSON)
 				.content(jsonRequest))
 			.andExpect(status().isCreated())
@@ -127,7 +127,7 @@ class ReviewControllerTest extends ControllerTest {
 		Review review = reviewRepository.save(createReview);
 
 		mockMvc.perform(get("/api/v1/reviews/{reviewId}", review.getId())
-				.header(HttpHeaders.AUTHORIZATION, BEARER_TYPE + ACCESS_TOKEN)
+				.header(HttpHeaders.AUTHORIZATION, BEARER_TYPE + accessToken)
 				.contentType(APPLICATION_JSON))
 			.andExpect(status().isOk())
 			.andDo(print())

--- a/src/test/java/com/prgrms/mukvengers/domain/review/api/ReviewControllerTest.java
+++ b/src/test/java/com/prgrms/mukvengers/domain/review/api/ReviewControllerTest.java
@@ -1,0 +1,182 @@
+package com.prgrms.mukvengers.domain.review.api;
+
+import static com.epages.restdocs.apispec.ResourceDocumentation.*;
+import static com.epages.restdocs.apispec.ResourceSnippetParameters.*;
+import static com.prgrms.mukvengers.utils.CrewObjectProvider.*;
+import static com.prgrms.mukvengers.utils.ReviewObjectProvider.*;
+import static com.prgrms.mukvengers.utils.UserObjectProvider.*;
+import static org.springframework.http.MediaType.*;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.*;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;
+import static org.springframework.restdocs.payload.JsonFieldType.*;
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpHeaders;
+
+import com.prgrms.mukvengers.base.ControllerTest;
+import com.prgrms.mukvengers.domain.crew.model.Crew;
+import com.prgrms.mukvengers.domain.crewmember.model.CrewMember;
+import com.prgrms.mukvengers.domain.review.dto.request.CreateLeaderReviewRequest;
+import com.prgrms.mukvengers.domain.review.dto.request.CreateMemberReviewRequest;
+import com.prgrms.mukvengers.domain.review.model.Review;
+import com.prgrms.mukvengers.domain.review.repository.ReviewRepository;
+import com.prgrms.mukvengers.domain.user.model.User;
+import com.prgrms.mukvengers.utils.ReviewObjectProvider;
+
+class ReviewControllerTest extends ControllerTest {
+
+	private static final String REVIEW = "리뷰 API";
+	@Autowired
+	ReviewController reviewController;
+
+	@Autowired
+	ReviewRepository reviewRepository;
+
+	User reviewer = savedUser;
+	User reviewee;
+	Crew crew;
+	CrewMember crewMember;
+
+	@BeforeEach
+	void setCrew() {
+		reviewer = userRepository.save(savedUser);
+		reviewee = userRepository.save(createUser());
+		crew = crewRepository.save(createCrew(reviewee, savedStore));
+
+		//crewMemberObjectProvider 변경 예정
+		CrewMember createCrewMember = CrewMember.builder()
+			.crew(crew)
+			.user(reviewer)
+			.ready(false)
+			.blocked(false)
+			.build();
+
+		crewMember = crewMemberRepository.save(createCrewMember);
+		crew.addCrewMember(crewMember);
+	}
+
+	@Test
+	@DisplayName("[성공] 밥모임 방장에 대해 리뷰를 생성할 수 있다")
+	void createReviewOfLeader_success() throws Exception {
+
+		CreateLeaderReviewRequest leaderReviewRequest = ReviewObjectProvider.createLeaderReviewRequest(
+			reviewee.getId());
+		String jsonRequest = objectMapper.writeValueAsString(leaderReviewRequest);
+
+		mockMvc.perform(post("/api/v1/crews/{crewId}/reviews/leader", crew.getId())
+				.header(HttpHeaders.AUTHORIZATION, BEARER_TYPE + ACCESS_TOKEN)
+				.contentType(APPLICATION_JSON)
+				.content(jsonRequest))
+			.andExpect(status().isCreated())
+			.andDo(document("reviewOfLeader-create",
+				resource(
+					builder()
+						.tag(REVIEW)
+						.requestFields(
+							fieldWithPath("revieweeId").description("방장의 아이디"),
+							fieldWithPath("content").description("추가로 작성하고 싶은 내용"),
+							fieldWithPath("mannerPoint").description("방장에 대한 매너 온도"),
+							fieldWithPath("tastePoint").description("방장에 대한 맛잘알 점수"))
+						.responseFields()
+						.build()
+				)
+			));
+	}
+
+	@Test
+	@DisplayName("[성공] 방장이 아닌 밥모임원에 대해 리뷰를 생성할 수 있다")
+	void createReviewOfMember_success() throws Exception {
+
+		CreateMemberReviewRequest memberReviewRequest = createReviewOfMemberRequest();
+
+		String jsonRequest = objectMapper.writeValueAsString(memberReviewRequest);
+
+		mockMvc.perform(post("/api/v1/crews/{crewId}/reviews/member", crew.getId())
+				.header(HttpHeaders.AUTHORIZATION, BEARER_TYPE + ACCESS_TOKEN)
+				.contentType(APPLICATION_JSON)
+				.content(jsonRequest))
+			.andExpect(status().isCreated())
+			.andDo(document("reviewOfMember-create",
+				resource(
+					builder()
+						.tag(REVIEW)
+						.requestFields(
+							fieldWithPath("revieweeId").description("리뷰이 아이디"),
+							fieldWithPath("content").description("추가로 작성하고 싶은 내용"),
+							fieldWithPath("mannerPoint").description("리뷰이에 대한 매너 온도"))
+						.responseFields()
+						.build()
+				)
+			));
+	}
+
+	@Test
+	@DisplayName("[성공] 리뷰 단건 조회할 수 있다.")
+	void getSingleReview() throws Exception {
+
+		Review createReview = createLeaderReview(reviewer, reviewee, savedStore);
+		Review review = reviewRepository.save(createReview);
+
+		mockMvc.perform(get("/api/v1/reviews/{reviewId}", review.getId())
+				.header(HttpHeaders.AUTHORIZATION, BEARER_TYPE + ACCESS_TOKEN)
+				.contentType(APPLICATION_JSON))
+			.andExpect(status().isOk())
+			.andDo(print())
+			.andDo(document("singleReview",
+				responseFields(
+					fieldWithPath("data.reviewer.id").description("리뷰어의 아이디"),
+					fieldWithPath("data.reviewer.nickname").description("리뷰어의 닉네임"),
+					fieldWithPath("data.reviewer.profileImgUrl").description("리뷰어의 프로필 이미지 주소"),
+					fieldWithPath("data.reviewer.introduction").description("리뷰어의 한줄 소개"),
+					fieldWithPath("data.reviewer.leaderCount").description("리뷰어의 리더 횟수"),
+					fieldWithPath("data.reviewer.crewCount").description("리뷰어의 밥모임 참여한 카운트"),
+					fieldWithPath("data.reviewer.tasteScore").description("리뷰어의 맛잘알 점수"),
+					fieldWithPath("data.reviewer.mannerScore").description("리뷰어의 매너 점수"),
+
+					fieldWithPath("data.reviewee.id").type(NUMBER).description("리뷰이의 아이디"),
+					fieldWithPath("data.reviewee.nickname").type(STRING).description("리뷰이의 닉네임"),
+					fieldWithPath("data.reviewee.profileImgUrl").type(STRING).description("리뷰이의 프로필 이미지 주소"),
+					fieldWithPath("data.reviewee.introduction").type(STRING).description("리뷰이의 한줄 소개"),
+					fieldWithPath("data.reviewee.leaderCount").type(NUMBER).description("리뷰이의 리더 횟수"),
+					fieldWithPath("data.reviewee.crewCount").type(NUMBER).description("리뷰이의 밥모임 참여한 횟수"),
+					fieldWithPath("data.reviewee.tasteScore").type(NUMBER).description("리뷰이의 맛잘알 점수"),
+					fieldWithPath("data.reviewee.mannerScore").type(NUMBER).description("리뷰이의 매너 점수"),
+
+					fieldWithPath("data.store.id").type(NUMBER).description("가게의 아이디"),
+					fieldWithPath("data.store.latitude").type(STRING).description("가게의 위도"),
+					fieldWithPath("data.store.longitude").type(STRING).description("가게의 경도"),
+					fieldWithPath("data.store.mapStoreId").type(STRING).description("지도 api 제공 id"),
+
+					fieldWithPath("data.crewName").type(STRING).description("리뷰하고자 하는 밥모임 이름"),
+					fieldWithPath("data.promiseTime").type(ARRAY).description("리뷰하고자 하는 밥모임 약속 시간"),
+					fieldWithPath("data.content").type(STRING).description("리뷰하고자 하는 밥모임 간단 한줄 리뷰 "),
+					fieldWithPath("data.mannerPoint").type(NUMBER).description("리뷰하고자 하는 밥모임 매너 온도"),
+					fieldWithPath("data.tastePoint").type(NUMBER).description("리뷰하고자 하는 밥모임 맛잘알 점수")
+					)
+			));
+	}
+
+	@NotNull
+	private CreateMemberReviewRequest createReviewOfMemberRequest() {
+		User otherCrewOne = userRepository.save(createUser());
+		CrewMember createCrewMember = CrewMember.builder()
+			.user(otherCrewOne)
+			.crew(crew)
+			.ready(false)
+			.blocked(false)
+			.build();
+
+		CrewMember otherCrewMember = crewMemberRepository.save(createCrewMember);
+		crew.addCrewMember(otherCrewMember);
+
+		return createMemberReviewRequest(
+			otherCrewOne.getId());
+	}
+}

--- a/src/test/java/com/prgrms/mukvengers/domain/review/service/ReviewServiceImplTest.java
+++ b/src/test/java/com/prgrms/mukvengers/domain/review/service/ReviewServiceImplTest.java
@@ -1,0 +1,107 @@
+package com.prgrms.mukvengers.domain.review.service;
+
+import static com.prgrms.mukvengers.utils.CrewObjectProvider.*;
+import static com.prgrms.mukvengers.utils.ReviewObjectProvider.*;
+import static com.prgrms.mukvengers.utils.UserObjectProvider.*;
+import static org.assertj.core.api.Assertions.*;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import com.prgrms.mukvengers.base.ServiceTest;
+import com.prgrms.mukvengers.domain.crew.model.Crew;
+import com.prgrms.mukvengers.domain.crewmember.model.CrewMember;
+import com.prgrms.mukvengers.domain.crewmember.repository.CrewMemberRepository;
+import com.prgrms.mukvengers.domain.review.dto.request.CreateLeaderReviewRequest;
+import com.prgrms.mukvengers.domain.review.dto.request.CreateMemberReviewRequest;
+import com.prgrms.mukvengers.domain.review.dto.response.ReviewResponse;
+import com.prgrms.mukvengers.domain.review.model.Review;
+import com.prgrms.mukvengers.domain.user.model.User;
+import com.prgrms.mukvengers.global.common.dto.IdResponse;
+
+class ReviewServiceImplTest extends ServiceTest {
+
+	@Autowired
+	CrewMemberRepository crewMemberRepository;
+
+	User reviewer;
+	User reviewee;
+
+	@BeforeEach
+	void setReview() {
+		reviewer = savedUser;
+		reviewee = userRepository.save(createUser());
+	}
+
+	@Test
+	@DisplayName("[성공] 리더에 대한 후기를 남길 경우 매너 온도와 맛잘알 평가를 할 수 있다.")
+	void createLeaderReviewTest_success() {
+
+		// given
+		Crew crew = crewRepository.save(createCrew(reviewee, savedStore));
+		CrewMember createCrewMember = CrewMember.builder()
+			.user(reviewer)
+			.crew(crew)
+			.build();
+
+		CrewMember createMember = crewMemberRepository.save(createCrewMember);
+		crew.addCrewMember(createMember);
+
+		CreateLeaderReviewRequest leaderReviewRequest = createLeaderReviewRequest(reviewee.getId());
+
+		// when
+		reviewService.createReviewOfLeader(leaderReviewRequest, reviewer.getId(), crew.getId());
+
+		// then
+		assertThat(createMember.getCrew().getLeader().getId()).isEqualTo(reviewee.getId());
+		assertThat(createMember.getCrew().getId()).isEqualTo(crew.getId());
+	}
+
+	@Test
+	@DisplayName("[성공] 밥모임원에 대한 후기를 남길 경우 매너 온도 평가를 할 수 있다.")
+	void createMemberReviewTest_success() {
+		// given
+		User leader = userRepository.save(createUser());
+		Crew crew = crewRepository.save(createCrew(leader, savedStore));
+
+		CrewMember createMemberOfReviewer = CrewMember.builder()
+			.user(reviewer)
+			.crew(crew)
+			.build();
+
+		CrewMember createMemberOfReviewee = CrewMember.builder()
+			.user(reviewee)
+			.crew(crew)
+			.build();
+
+		CrewMember crewMemberOfReviewer = crewMemberRepository.save(createMemberOfReviewer);
+		CrewMember crewMemberOfReviewee = crewMemberRepository.save(createMemberOfReviewee);
+
+		CreateMemberReviewRequest memberReviewRequest = createMemberReviewRequest(reviewee.getId());
+
+		// when
+		IdResponse review = reviewService.createMemberReview(memberReviewRequest,
+			crewMemberOfReviewer.getUser().getId(), crew.getId());
+
+		Review saveReview = reviewRepository.findById(review.id()).get();
+
+		// then
+		assertThat(saveReview.getMannerPoint()).isEqualTo(MANNER_POINT);
+		assertThat(crewMemberOfReviewer.getCrew().getId()).isEqualTo(crewMemberOfReviewee.getCrew().getId());
+	}
+
+	@Test
+	@DisplayName("[성공] reviewer가 본인이면 단건 리뷰 조회할 수 있다.")
+	void getSingleLeaderReview() {
+		// given
+		Review review = reviewRepository.save(createLeaderReview(reviewer, reviewee, savedStore));
+
+		// when
+		ReviewResponse singleReview = reviewService.getSingleReview(review.getId(), reviewer.getId());
+
+		// then
+		assertThat(singleReview.reviewer().id()).isEqualTo(reviewer.getId());
+	}
+}

--- a/src/test/java/com/prgrms/mukvengers/domain/store/api/StoreControllerTest.java
+++ b/src/test/java/com/prgrms/mukvengers/domain/store/api/StoreControllerTest.java
@@ -1,8 +1,10 @@
 package com.prgrms.mukvengers.domain.store.api;
 
+import static com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper.*;
+import static com.epages.restdocs.apispec.ResourceDocumentation.*;
+import static com.epages.restdocs.apispec.ResourceSnippetParameters.*;
 import static org.hamcrest.Matchers.*;
 import static org.springframework.http.MediaType.*;
-import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.*;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;
 import static org.springframework.restdocs.payload.JsonFieldType.*;
 import static org.springframework.restdocs.payload.PayloadDocumentation.*;
@@ -12,14 +14,18 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import com.epages.restdocs.apispec.Schema;
 import com.prgrms.mukvengers.base.ControllerTest;
 import com.prgrms.mukvengers.domain.store.dto.request.CreateStoreRequest;
 import com.prgrms.mukvengers.utils.StoreObjectProvider;
 
 class StoreControllerTest extends ControllerTest {
 
+	public static final Schema CREATE_STORE_REQUEST = new Schema("createStoreRequest");
+	public static final Schema STORE_RESPONSE = new Schema("storeResponse");
+
 	@Test
-	@DisplayName("[성공]가게를 저장한다.")
+	@DisplayName("[성공] 가게를 저장한다.")
 	void create_success() throws Exception {
 
 		CreateStoreRequest createStoreRequest = StoreObjectProvider.getCreateStoreRequest("123456789");
@@ -35,10 +41,20 @@ class StoreControllerTest extends ControllerTest {
 			.andExpect(redirectedUrlPattern("http://localhost:8080/api/v1/stores/*"))
 			.andDo(print())
 			.andDo(document("store-create",
-				requestFields(
-					fieldWithPath("latitude").type(STRING).description("위도"),
-					fieldWithPath("longitude").type(STRING).description("경도"),
-					fieldWithPath("mapStoreId").type(STRING).description("지도 api 제공 id")
+				resource(
+					builder()
+						.tags(STORE)
+						.summary("가게 저장 API")
+						.requestSchema(CREATE_STORE_REQUEST)
+						.responseSchema(STORE_RESPONSE)
+						.description("가게 정보를 저장합니다.")
+						.requestFields(
+							fieldWithPath("latitude").type(STRING).description("위도"),
+							fieldWithPath("longitude").type(STRING).description("경도"),
+							fieldWithPath("mapStoreId").type(STRING).description("지도 api 제공 id"))
+						.responseHeaders(
+							headerWithName("Location").description("조회해볼 수 있는 요청 주소"))
+						.build()
 				)
 			));
 	}

--- a/src/test/java/com/prgrms/mukvengers/domain/user/api/UserControllerTest.java
+++ b/src/test/java/com/prgrms/mukvengers/domain/user/api/UserControllerTest.java
@@ -1,134 +1,180 @@
 package com.prgrms.mukvengers.domain.user.api;
 
+import static com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper.*;
+import static com.epages.restdocs.apispec.ResourceDocumentation.*;
+import static com.epages.restdocs.apispec.ResourceSnippetParameters.*;
 import static com.prgrms.mukvengers.utils.UserObjectProvider.*;
+import static org.springframework.http.HttpHeaders.*;
+import static org.springframework.http.MediaType.*;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;
 import static org.springframework.restdocs.payload.JsonFieldType.*;
 import static org.springframework.restdocs.payload.PayloadDocumentation.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.MediaType;
-import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
 
+import com.epages.restdocs.apispec.Schema;
 import com.prgrms.mukvengers.base.ControllerTest;
 import com.prgrms.mukvengers.domain.user.dto.request.UpdateUserRequest;
 import com.prgrms.mukvengers.domain.user.model.User;
 
 class UserControllerTest extends ControllerTest {
 
+	private static final Schema userResponseSchema = new Schema("myProfileResponse");
+
 	@Test
 	@DisplayName("[성공] 사용자는 자신의 프로필 정보를 확인할 수 있다")
-	void getMyProfileSuccessTest() throws Exception {
+	void getMyProfile_success() throws Exception {
 		// when
-		mockMvc.perform(RestDocumentationRequestBuilders.get("/api/v1/user/me")
-				.header(HttpHeaders.AUTHORIZATION, BEARER_TYPE + ACCESS_TOKEN)
-			)
+		mockMvc.perform(get("/api/v1/user/me")
+				.header(AUTHORIZATION, BEARER_TYPE + accessToken))
 			// then
 			.andExpectAll(
 				handler().methodName("getMyProfile"),
 				status().isOk())
+			.andExpect(jsonPath("$.data").exists())
+			.andDo(print())
 			// docs
-			.andDo(restDocs.document(
-				responseFields(
-					fieldWithPath("data.id").type(NUMBER).description("유저 ID"),
-					fieldWithPath("data.nickname").type(STRING).description("닉네임"),
-					fieldWithPath("data.profileImgUrl").type(STRING).description("프로필 이미지"),
-					fieldWithPath("data.introduction").type(STRING).description("한줄 소개"),
-					fieldWithPath("data.leaderCount").type(NUMBER).description("방장 횟수"),
-					fieldWithPath("data.leaderCount").type(NUMBER).description("방장 횟수"),
-					fieldWithPath("data.crewCount").type(NUMBER).description("모임 참여 횟수"),
-					fieldWithPath("data.tasteScore").type(NUMBER).description("맛잘알 점수"),
-					fieldWithPath("data.mannerScore").type(NUMBER).description("매너 온도")
-
+			.andDo(document("getMyProfile",
+				resource(
+					builder()
+						.tags(USER)
+						.summary("내 정보 조회 API")
+						.responseSchema(userResponseSchema)
+						.description("내 정보를 조회합니다.")
+						.requestHeaders(
+							headerWithName(AUTHORIZATION).description("accessToken"))
+						.responseFields(
+							fieldWithPath("data.id").type(NUMBER).description("유저 ID"),
+							fieldWithPath("data.nickname").type(STRING).description("닉네임"),
+							fieldWithPath("data.profileImgUrl").type(STRING).description("프로필 이미지"),
+							fieldWithPath("data.introduction").type(STRING).description("한줄 소개"),
+							fieldWithPath("data.leaderCount").type(NUMBER).description("방장 횟수"),
+							fieldWithPath("data.leaderCount").type(NUMBER).description("방장 횟수"),
+							fieldWithPath("data.crewCount").type(NUMBER).description("모임 참여 횟수"),
+							fieldWithPath("data.tasteScore").type(NUMBER).description("맛잘알 점수"),
+							fieldWithPath("data.mannerScore").type(NUMBER).description("매너 온도"))
+						.build()
 				))
 			);
 	}
 
 	@Test
 	@DisplayName("[성공] 유저 아이디로 유저 정보를 조회할 수 있다.")
-	void getUserProfileSuccessTest() throws Exception {
+	void getUserProfile_success() throws Exception {
 		// when
-		mockMvc.perform(RestDocumentationRequestBuilders
-				.get("/api/v1/user/{userId}", savedUserId)
-				.header(HttpHeaders.AUTHORIZATION, BEARER_TYPE + ACCESS_TOKEN)
+		mockMvc.perform(get("/api/v1/user/{userId}", savedUserId)
+				.header(AUTHORIZATION, BEARER_TYPE + accessToken)
 			)
 			// then
 			.andExpectAll(
 				handler().methodName("getUserProfile"),
 				status().isOk())
+			.andExpect(jsonPath("$.data").exists())
+			.andDo(print())
 			// docs
-			.andDo(restDocs.document(
-				responseFields(
-					fieldWithPath("data.id").type(NUMBER).description("유저 ID"),
-					fieldWithPath("data.nickname").type(STRING).description("닉네임"),
-					fieldWithPath("data.profileImgUrl").type(STRING).description("프로필 이미지"),
-					fieldWithPath("data.introduction").type(STRING).description("한줄 소개"),
-					fieldWithPath("data.leaderCount").type(NUMBER).description("방장 횟수"),
-					fieldWithPath("data.leaderCount").type(NUMBER).description("방장 횟수"),
-					fieldWithPath("data.crewCount").type(NUMBER).description("모임 참여 횟수"),
-					fieldWithPath("data.tasteScore").type(NUMBER).description("맛잘알 점수"),
-					fieldWithPath("data.mannerScore").type(NUMBER).description("매너 온도")
+			.andDo(document("getUserProfile",
+				resource(
+					builder()
+						.tags(USER)
+						.summary("내 정보 조회 API")
+						.responseSchema(userResponseSchema)
+						.description("유저 아이디로 공개된 유저 정보를 조회합니다.")
+						.pathParameters(
+							parameterWithName("userId").description("조회하고자 하는 유저의 아이디"))
+						.responseFields(
+							fieldWithPath("data.id").type(NUMBER).description("유저 ID"),
+							fieldWithPath("data.nickname").type(STRING).description("닉네임"),
+							fieldWithPath("data.profileImgUrl").type(STRING).description("프로필 이미지"),
+							fieldWithPath("data.introduction").type(STRING).description("한줄 소개"),
+							fieldWithPath("data.leaderCount").type(NUMBER).description("방장 횟수"),
+							fieldWithPath("data.leaderCount").type(NUMBER).description("방장 횟수"),
+							fieldWithPath("data.crewCount").type(NUMBER).description("모임 참여 횟수"),
+							fieldWithPath("data.tasteScore").type(NUMBER).description("맛잘알 점수"),
+							fieldWithPath("data.mannerScore").type(NUMBER).description("매너 온도"))
+						.build()
 				))
 			);
 	}
 
 	@Test
 	@DisplayName("[성공] 자신의 프로필을 수정할 수 있다.")
-	void updateMyProfileSuccessTest() throws Exception {
+	void updateMyProfile_success() throws Exception {
+		// given
 		UpdateUserRequest request = getUpdateUserRequest();
 
 		// when
-		mockMvc.perform(RestDocumentationRequestBuilders.put("/api/v1/user/me")
-				.header(HttpHeaders.AUTHORIZATION, BEARER_TYPE + ACCESS_TOKEN)
-				.contentType(MediaType.APPLICATION_JSON)
+		mockMvc.perform(put("/api/v1/user/me")
+				.header(AUTHORIZATION, BEARER_TYPE + accessToken)
+				.contentType(APPLICATION_JSON)
 				.content(objectMapper.writeValueAsString(request))
 			)
 			// then
 			.andExpectAll(
 				handler().methodName("updateMyProfile"),
 				status().isOk())
+			.andExpect(jsonPath("$.data").exists())
+			.andDo(print())
 			// docs
-			.andDo(restDocs.document(
-				responseFields(
-					fieldWithPath("data.id").type(NUMBER).description("유저 ID"),
-					fieldWithPath("data.nickname").type(STRING).description("닉네임"),
-					fieldWithPath("data.profileImgUrl").type(STRING).description("프로필 이미지"),
-					fieldWithPath("data.introduction").type(STRING).description("한줄 소개"),
-					fieldWithPath("data.leaderCount").type(NUMBER).description("방장 횟수"),
-					fieldWithPath("data.leaderCount").type(NUMBER).description("방장 횟수"),
-					fieldWithPath("data.crewCount").type(NUMBER).description("모임 참여 횟수"),
-					fieldWithPath("data.tasteScore").type(NUMBER).description("맛잘알 점수"),
-					fieldWithPath("data.mannerScore").type(NUMBER).description("매너 온도")
+			.andDo(document("updateMyProfile",
+				resource(
+					builder()
+						.tags(USER)
+						.summary("내 정보 수정 API")
+						.responseSchema(userResponseSchema)
+						.description("내 정보를 수정합니다.")
+						.responseFields(
+							fieldWithPath("data.id").type(NUMBER).description("유저 ID"),
+							fieldWithPath("data.nickname").type(STRING).description("닉네임"),
+							fieldWithPath("data.profileImgUrl").type(STRING).description("프로필 이미지"),
+							fieldWithPath("data.introduction").type(STRING).description("한줄 소개"),
+							fieldWithPath("data.leaderCount").type(NUMBER).description("방장 횟수"),
+							fieldWithPath("data.leaderCount").type(NUMBER).description("방장 횟수"),
+							fieldWithPath("data.crewCount").type(NUMBER).description("모임 참여 횟수"),
+							fieldWithPath("data.tasteScore").type(NUMBER).description("맛잘알 점수"),
+							fieldWithPath("data.mannerScore").type(NUMBER).description("매너 온도"))
+						.build()
 				))
 			);
-
 	}
 
 	@Test
 	@DisplayName("자신의 계정을 삭제할 수 있다")
-	void deleteMyProfileSuccessTest() throws Exception {
+	void deleteMyProfile_success() throws Exception {
 
-		//given
+		// given
 		User createdUser = User.builder()
 			.nickname(DEFAULT_NICKNAME)
 			.profileImgUrl(DEFAULT_PROFILE_IMG_URL)
 			.provider(PROVIDER_KAKAO)
 			.oauthId(OAUTH_ID)
 			.build();
+		User savedUser = userRepository.save(createdUser);
 
-		User user = userRepository.save(createdUser);
-		Long userId = user.getId();
-		String token = jwtTokenProvider.createAccessToken(userId, "USER");
+		Long userId = savedUser.getId();
+
+		String accessToken = jwtTokenProvider.createAccessToken(userId, "USER");
 
 		// when
-		mockMvc.perform(RestDocumentationRequestBuilders.delete("/api/v1/user/me")
-				.header(HttpHeaders.AUTHORIZATION, BEARER_TYPE + token)
-			)
+		mockMvc.perform(delete("/api/v1/user/me")
+				.header(AUTHORIZATION, BEARER_TYPE + accessToken))
 			// then
 			.andExpectAll(
 				handler().methodName("deleteMyProfile"),
-				status().isNoContent()
+				status().isNoContent())
+			.andDo(print())
+			.andDo(document("deleteMyProfile",
+				resource(
+					builder()
+						.tags(USER)
+						.summary("내 정보 삭제 API")
+						.description("내 정보를 삭제합니다.")
+						.responseSchema(new Schema("NONE"))
+						.build()
+				))
 			);
+
 	}
 }

--- a/src/test/java/com/prgrms/mukvengers/utils/ReviewObjectProvider.java
+++ b/src/test/java/com/prgrms/mukvengers/utils/ReviewObjectProvider.java
@@ -1,0 +1,60 @@
+package com.prgrms.mukvengers.utils;
+
+import java.time.LocalDateTime;
+
+import com.prgrms.mukvengers.domain.review.dto.request.CreateLeaderReviewRequest;
+import com.prgrms.mukvengers.domain.review.dto.request.CreateMemberReviewRequest;
+import com.prgrms.mukvengers.domain.review.model.Review;
+import com.prgrms.mukvengers.domain.store.model.Store;
+import com.prgrms.mukvengers.domain.user.model.User;
+
+public class ReviewObjectProvider {
+
+	private static final LocalDateTime PROMISE_TIME = LocalDateTime.now();
+	private static final String CREW_NAME = "밥모임 이름";
+	private static final String CONTENT = "추가로 작성하고 싶은 내용을 입력해주세요.";
+	public static final Integer MANNER_POINT = 10;
+	private static final Integer TASTE_POINT = 5;
+
+	public static Review createLeaderReview(User reviewer, User reviewee, Store store) {
+		return Review.builder()
+			.reviewer(reviewer)
+			.reviewee(reviewee)
+			.store(store)
+			.promiseTime(PROMISE_TIME)
+			.crewName(CREW_NAME)
+			.content(CONTENT)
+			.mannerPoint(MANNER_POINT)
+			.tastePoint(TASTE_POINT)
+			.build();
+	}
+
+	public static Review createMemberReview(User reviewer, User reviewee, Store store) {
+		return Review.builder()
+			.reviewer(reviewer)
+			.reviewee(reviewee)
+			.store(store)
+			.promiseTime(PROMISE_TIME)
+			.crewName(CREW_NAME)
+			.content(CONTENT)
+			.mannerPoint(MANNER_POINT)
+			.build();
+	}
+
+	public static CreateLeaderReviewRequest createLeaderReviewRequest(Long revieweeId) {
+		return new CreateLeaderReviewRequest(
+			revieweeId,
+			CONTENT,
+			MANNER_POINT,
+			TASTE_POINT
+		);
+	}
+
+	public static CreateMemberReviewRequest createMemberReviewRequest(Long revieweeId) {
+		return new CreateMemberReviewRequest(
+			revieweeId,
+			CONTENT,
+			MANNER_POINT
+		);
+	}
+}


### PR DESCRIPTION
<!-- 제목은 `[#이슈번호] 제목` 으로 작성한다. ex) [#8] 결제 기능 -->

### 🌱 작업 사항 
- 방장에 대한 매너온도와 맛잘알 리뷰를 생성할 수 있다.
- 방장이 아닌 일반 밥모임원 대한 매너온도 리뷰를 생성할 수 있다.
- 리뷰의 단건 조회
- RestDocs로 API 문서화

### ❓ 리뷰 포인트
작성해보니깐` crewMemberRepository.findCrewMemberByCrewId` 필요없을꺼 같은데 어떻게 생각하시나요?

### 🦄 관련 이슈
resolves #15 #16  <!-- pr이 머지되면 이슈가 자동으로 close되게 합니다. 만약 자동 close를 하지 않고 이슈만 링크한다면 resolves를 삭제한다.-->



