### PR TITLE
[#54] 검색 범위 거리를 프론트에서 파라미터로 받도록 수정 

### DIFF
--- a/src/main/java/com/prgrms/mukvengers/domain/crew/api/CrewController.java
+++ b/src/main/java/com/prgrms/mukvengers/domain/crew/api/CrewController.java
@@ -12,16 +12,17 @@ import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 
 import com.prgrms.mukvengers.domain.crew.dto.request.CreateCrewRequest;
+import com.prgrms.mukvengers.domain.crew.dto.request.DistanceRequest;
 import com.prgrms.mukvengers.domain.crew.dto.request.UpdateStatusRequest;
 import com.prgrms.mukvengers.domain.crew.dto.response.CrewPageResponse;
 import com.prgrms.mukvengers.domain.crew.dto.response.CrewResponses;
@@ -83,16 +84,14 @@ public class CrewController {
 	 * <pre>
 	 *     사용자의 위도, 경도로 특정 거리 안에 있는 밥 모임 조회
 	 * </pre>
-	 * @param latitude 사용자 위도
-	 * @param longitude 사용자 경도
+	 * @param distanceRequest 사용자 경도, 위도, 모임을 찾을 반경 거리 정보를 가진 DTO
 	 * @return status : 200, body : 사용자 위치를 기반으로 특정 거리 안에 있는 밥 모임 정보
 	 */
 	@GetMapping(produces = APPLICATION_JSON_VALUE)
 	public ResponseEntity<ApiResponse<CrewResponses>> findByLocation(
-		@RequestParam("latitude") String latitude,
-		@RequestParam("longitude") String longitude
+		@ModelAttribute @Valid DistanceRequest distanceRequest
 	) {
-		CrewResponses responses = crewService.getByLocation(longitude, latitude);
+		CrewResponses responses = crewService.getByLocation(distanceRequest);
 
 		return ResponseEntity.ok().body(new ApiResponse<>(responses));
 	}

--- a/src/main/java/com/prgrms/mukvengers/domain/crew/dto/request/DistanceRequest.java
+++ b/src/main/java/com/prgrms/mukvengers/domain/crew/dto/request/DistanceRequest.java
@@ -1,0 +1,10 @@
+package com.prgrms.mukvengers.domain.crew.dto.request;
+
+import javax.validation.constraints.NotNull;
+
+public record DistanceRequest(
+	@NotNull Double longitude,
+	@NotNull Double latitude,
+	@NotNull Integer distance
+) {
+}

--- a/src/main/java/com/prgrms/mukvengers/domain/crew/service/CrewService.java
+++ b/src/main/java/com/prgrms/mukvengers/domain/crew/service/CrewService.java
@@ -3,6 +3,7 @@ package com.prgrms.mukvengers.domain.crew.service;
 import org.springframework.data.domain.Pageable;
 
 import com.prgrms.mukvengers.domain.crew.dto.request.CreateCrewRequest;
+import com.prgrms.mukvengers.domain.crew.dto.request.DistanceRequest;
 import com.prgrms.mukvengers.domain.crew.dto.request.UpdateStatusRequest;
 import com.prgrms.mukvengers.domain.crew.dto.response.CrewPageResponse;
 import com.prgrms.mukvengers.domain.crew.dto.response.CrewResponses;
@@ -14,7 +15,7 @@ public interface CrewService {
 
 	CrewPageResponse getByMapStoreId(String mapStoreId, Pageable pageable);
 
-	CrewResponses getByLocation(String longitude, String latitude);
+	CrewResponses getByLocation(DistanceRequest distanceRequest);
 
 	void updateStatus(UpdateStatusRequest updateStatusRequest);
 

--- a/src/main/java/com/prgrms/mukvengers/domain/crew/service/CrewServiceImpl.java
+++ b/src/main/java/com/prgrms/mukvengers/domain/crew/service/CrewServiceImpl.java
@@ -11,6 +11,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.prgrms.mukvengers.domain.crew.dto.request.CreateCrewRequest;
+import com.prgrms.mukvengers.domain.crew.dto.request.DistanceRequest;
 import com.prgrms.mukvengers.domain.crew.dto.request.UpdateStatusRequest;
 import com.prgrms.mukvengers.domain.crew.dto.response.CrewPageResponse;
 import com.prgrms.mukvengers.domain.crew.dto.response.CrewResponse;
@@ -65,12 +66,12 @@ public class CrewServiceImpl implements CrewService {
 	}
 
 	@Override
-	public CrewResponses getByLocation(String longitude, String latitude) {
+	public CrewResponses getByLocation(DistanceRequest distanceRequest) {
 		GeometryFactory gf = new GeometryFactory();
 
-		Point location = gf.createPoint(new Coordinate(Double.parseDouble(longitude), Double.parseDouble(latitude)));
+		Point location = gf.createPoint(new Coordinate(distanceRequest.longitude(), distanceRequest.latitude()));
 
-		List<CrewResponse> responses = crewRepository.findAllByLocation(location, 500)
+		List<CrewResponse> responses = crewRepository.findAllByLocation(location, distanceRequest.distance())
 			.stream().map(crewMapper::toCrewResponse).toList();
 
 		return new CrewResponses(responses);

--- a/src/test/java/com/prgrms/mukvengers/domain/crew/api/CrewControllerTest.java
+++ b/src/test/java/com/prgrms/mukvengers/domain/crew/api/CrewControllerTest.java
@@ -165,10 +165,12 @@ class CrewControllerTest extends ControllerTest {
 
 		String latitude = "35.75413579";
 		String longitude = "-147.4654321321";
+		String distance = "500";
 
 		MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
 		params.add("latitude", latitude);
 		params.add("longitude", longitude);
+		params.add("distance", distance);
 
 		mockMvc.perform(get("/api/v1/crews")
 				.params(params)
@@ -186,7 +188,8 @@ class CrewControllerTest extends ControllerTest {
 						.requestSchema(FIND_BY_USER_LOCATION_CREW_REQUEST)
 						.requestParameters(
 							parameterWithName("latitude").description("사용자의 위도"),
-							parameterWithName("longitude").description("사용자의 경도"))
+							parameterWithName("longitude").description("사용자의 경도"),
+							parameterWithName("distance").description("모임을 찾을 범위 거리"))
 						.responseSchema(CREW_RESPONSE)
 						.responseFields(
 							fieldWithPath("data.responses.[].id").type(NUMBER).description("밥 모임 아이디"),

--- a/src/test/java/com/prgrms/mukvengers/domain/crew/service/CrewServiceImplTest.java
+++ b/src/test/java/com/prgrms/mukvengers/domain/crew/service/CrewServiceImplTest.java
@@ -15,6 +15,7 @@ import org.springframework.data.domain.Slice;
 
 import com.prgrms.mukvengers.base.ServiceTest;
 import com.prgrms.mukvengers.domain.crew.dto.request.CreateCrewRequest;
+import com.prgrms.mukvengers.domain.crew.dto.request.DistanceRequest;
 import com.prgrms.mukvengers.domain.crew.dto.request.UpdateStatusRequest;
 import com.prgrms.mukvengers.domain.crew.dto.response.CrewPageResponse;
 import com.prgrms.mukvengers.domain.crew.dto.response.CrewResponse;
@@ -83,10 +84,13 @@ class CrewServiceImplTest extends ServiceTest {
 
 		crewRepository.save(crew);
 
-		String latitude = "35.75413579";
-		String longitude = "-147.4654321321";
+		Double latitude = 35.75413579;
+		Double longitude = -147.4654321321;
+		Integer distance = 500;
 
-		CrewResponses crewResponses = crewService.getByLocation(longitude, latitude);
+		DistanceRequest distanceRequest = new DistanceRequest(longitude, latitude, distance);
+
+		CrewResponses crewResponses = crewService.getByLocation(distanceRequest);
 
 		List<CrewResponse> responses = crewResponses.responses();
 


### PR DESCRIPTION

### 🌱 작업 사항 
- RequestParam을 ModelAttribute로 변경하였습니다.
- 파리미터로 거리를 받로록 추가하였습니다.
- 거리계산이 500미터 고정값에서 파라미터로 받은 거리 이하의 모임을 계산하여 조회합니다.
### ❓ 리뷰 포인트

### 🦄 관련 이슈
resolves #54 



