### PR TITLE
[#38] Refresh Token 기능 구현

### DIFF
--- a/src/main/java/com/prgrms/mukvengers/global/security/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/prgrms/mukvengers/global/security/jwt/JwtTokenProvider.java
@@ -3,6 +3,7 @@ package com.prgrms.mukvengers.global.security.jwt;
 import java.nio.charset.StandardCharsets;
 import java.util.Date;
 import java.util.Map;
+import java.util.UUID;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
@@ -69,4 +70,7 @@ public class JwtTokenProvider {
 		}
 	}
 
+	public String createRefreshToken() {
+		return UUID.randomUUID().toString();
+	}
 }

--- a/src/main/java/com/prgrms/mukvengers/global/security/oauth/dto/AuthUserInfo.java
+++ b/src/main/java/com/prgrms/mukvengers/global/security/oauth/dto/AuthUserInfo.java
@@ -1,0 +1,7 @@
+package com.prgrms.mukvengers.global.security.oauth.dto;
+
+public record AuthUserInfo(
+	Long id,
+	String role
+) {
+}

--- a/src/main/java/com/prgrms/mukvengers/global/security/oauth/service/OAuthService.java
+++ b/src/main/java/com/prgrms/mukvengers/global/security/oauth/service/OAuthService.java
@@ -6,7 +6,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.prgrms.mukvengers.domain.user.model.User;
 import com.prgrms.mukvengers.domain.user.repository.UserRepository;
-import com.prgrms.mukvengers.global.security.jwt.JwtTokenProvider;
+import com.prgrms.mukvengers.global.security.oauth.dto.AuthUserInfo;
 import com.prgrms.mukvengers.global.security.oauth.dto.OAuthUserInfo;
 import com.prgrms.mukvengers.global.security.oauth.mapper.OAuthMapper;
 
@@ -16,14 +16,13 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 @Service
 @RequiredArgsConstructor
-public class OAuthService {
-
-	private final JwtTokenProvider jwtTokenProvider;
+public class OAuthService { // TODO: 현재 상당히 객체 지향적으로 좋지 않아 보임
+	
 	private final UserRepository userRepository;
 	private final OAuthMapper oauthMapper;
 
 	@Transactional
-	public String login(OAuth2User oauth2User, String providerName) {
+	public AuthUserInfo login(OAuth2User oauth2User, String providerName) {
 
 		OAuthUserInfo oauthUserInfo = OAuthProvider
 			.getOAuthProviderByName(providerName)
@@ -34,8 +33,8 @@ public class OAuthService {
 			.findByUserIdByProviderAndOauthId(oauthUserInfo.provider(), oauthUserInfo.oauthId())
 			.orElseGet(() -> userRepository.save(oauthMapper.toUser(oauthUserInfo)));
 
-		String accessToken = jwtTokenProvider.createAccessToken(user.getId(), "ROLE_USER");
-		log.debug("{}를 통해 로그인 한 사용자(ID: {}), accessToken = {}", providerName, user.getId(), accessToken);
-		return accessToken;
+		log.debug("{}를 통해 로그인 한 사용자(ID: {})", providerName, user.getId());
+
+		return new AuthUserInfo(user.getId(), "ROLE_USER");
 	}
 }

--- a/src/main/java/com/prgrms/mukvengers/global/security/token/api/TokenController.java
+++ b/src/main/java/com/prgrms/mukvengers/global/security/token/api/TokenController.java
@@ -1,0 +1,47 @@
+package com.prgrms.mukvengers.global.security.token.api;
+
+import static org.springframework.http.HttpStatus.*;
+
+import javax.validation.Valid;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.prgrms.mukvengers.global.common.dto.ApiResponse;
+import com.prgrms.mukvengers.global.security.jwt.JwtAuthentication;
+import com.prgrms.mukvengers.global.security.token.dto.request.CreateAccessTokenRequest;
+import com.prgrms.mukvengers.global.security.token.dto.response.TokenResponse;
+import com.prgrms.mukvengers.global.security.token.service.TokenService;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/tokens")
+public class TokenController {
+
+	private final TokenService tokenService;
+
+	@PostMapping
+	public ResponseEntity<ApiResponse<TokenResponse>> getTokensByRefreshToken(
+		@RequestBody @Valid CreateAccessTokenRequest createAccessTokenRequest
+	) {
+		TokenResponse response = tokenService.renewTokens(createAccessTokenRequest);
+
+		return ResponseEntity.ok().body(new ApiResponse<>(response));
+	}
+
+	@DeleteMapping
+	@ResponseStatus(NO_CONTENT)
+	public void deleteRefreshToken(
+		@AuthenticationPrincipal JwtAuthentication user
+	) {
+		tokenService.deleteTokenByUserId(user.id());
+	}
+}

--- a/src/main/java/com/prgrms/mukvengers/global/security/token/dto/request/CreateAccessTokenRequest.java
+++ b/src/main/java/com/prgrms/mukvengers/global/security/token/dto/request/CreateAccessTokenRequest.java
@@ -1,0 +1,8 @@
+package com.prgrms.mukvengers.global.security.token.dto.request;
+
+import javax.validation.constraints.NotBlank;
+
+public record CreateAccessTokenRequest(
+	@NotBlank String refreshToken
+) {
+}

--- a/src/main/java/com/prgrms/mukvengers/global/security/token/dto/response/TokenResponse.java
+++ b/src/main/java/com/prgrms/mukvengers/global/security/token/dto/response/TokenResponse.java
@@ -1,0 +1,8 @@
+package com.prgrms.mukvengers.global.security.token.dto.response;
+
+public record TokenResponse(
+	Long userId,
+	String accessToken,
+	String refreshToken
+) {
+}

--- a/src/main/java/com/prgrms/mukvengers/global/security/token/exception/RefreshTokenNotFoundException.java
+++ b/src/main/java/com/prgrms/mukvengers/global/security/token/exception/RefreshTokenNotFoundException.java
@@ -1,0 +1,15 @@
+package com.prgrms.mukvengers.global.security.token.exception;
+
+import com.prgrms.mukvengers.global.exception.ErrorCode;
+import com.prgrms.mukvengers.global.exception.ServiceException;
+
+public class RefreshTokenNotFoundException extends ServiceException {
+
+	private static final ErrorCode ERROR_CODE = ErrorCode.USER_NOT_FOUND;
+	private static final String MESSAGE_KEY = "exception.user.notfound";
+
+	public RefreshTokenNotFoundException(String refreshToken) {
+		super(ERROR_CODE, MESSAGE_KEY, new String[] {refreshToken});
+	}
+
+}

--- a/src/main/java/com/prgrms/mukvengers/global/security/token/model/Token.java
+++ b/src/main/java/com/prgrms/mukvengers/global/security/token/model/Token.java
@@ -1,0 +1,29 @@
+package com.prgrms.mukvengers.global.security.token.model;
+
+import static lombok.AccessLevel.*;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = PROTECTED)
+public class Token {
+
+	@Id
+	@Column(nullable = false, unique = true)
+	private String refreshToken;
+
+	@Column(nullable = false, unique = true)
+	private long userId;
+
+	public Token(String refreshToken, Long userId) {
+		this.refreshToken = refreshToken;
+		this.userId = userId;
+	}
+
+}

--- a/src/main/java/com/prgrms/mukvengers/global/security/token/repository/TokenRepository.java
+++ b/src/main/java/com/prgrms/mukvengers/global/security/token/repository/TokenRepository.java
@@ -1,0 +1,12 @@
+package com.prgrms.mukvengers.global.security.token.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.prgrms.mukvengers.global.security.token.model.Token;
+
+public interface TokenRepository extends JpaRepository<Token, String> {
+
+	Optional<Token> findByUserId(Long refreshToken);
+}

--- a/src/main/java/com/prgrms/mukvengers/global/security/token/service/TokenService.java
+++ b/src/main/java/com/prgrms/mukvengers/global/security/token/service/TokenService.java
@@ -1,0 +1,57 @@
+package com.prgrms.mukvengers.global.security.token.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.prgrms.mukvengers.domain.user.exception.UserNotFoundException;
+import com.prgrms.mukvengers.global.security.jwt.JwtTokenProvider;
+import com.prgrms.mukvengers.global.security.oauth.dto.AuthUserInfo;
+import com.prgrms.mukvengers.global.security.token.dto.request.CreateAccessTokenRequest;
+import com.prgrms.mukvengers.global.security.token.dto.response.TokenResponse;
+import com.prgrms.mukvengers.global.security.token.exception.RefreshTokenNotFoundException;
+import com.prgrms.mukvengers.global.security.token.model.Token;
+import com.prgrms.mukvengers.global.security.token.repository.TokenRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class TokenService {
+
+	private final JwtTokenProvider jwtTokenProvider;
+	private final TokenRepository tokenRepository;
+
+	@Transactional
+	public TokenResponse createToken(AuthUserInfo user) {
+
+		String accessToken = jwtTokenProvider.createAccessToken(user.id(), user.role());
+		String refreshToken = jwtTokenProvider.createRefreshToken();
+
+		tokenRepository.save(new Token(refreshToken, user.id()));
+
+		return new TokenResponse(user.id(), accessToken, refreshToken);
+	}
+
+	@Transactional
+	public TokenResponse renewTokens(CreateAccessTokenRequest createAccessTokenRequest) {
+		String refreshToken = createAccessTokenRequest.refreshToken();
+
+		Token token = tokenRepository.findById(refreshToken)
+			.orElseThrow(() -> new RefreshTokenNotFoundException(refreshToken));
+
+		tokenRepository.delete(token);
+		AuthUserInfo user = new AuthUserInfo(token.getUserId(), "USER");
+
+		return createToken(user);
+	}
+
+	@Transactional
+	public void deleteTokenByUserId(Long userId) {
+		tokenRepository.findByUserId(userId)
+			.ifPresentOrElse(tokenRepository::delete,
+				() -> {
+					throw new UserNotFoundException(userId);
+				});
+	}
+}


### PR DESCRIPTION
#### 해당 PR로 RefreshToken 기능이 정상 동작하지는 않습니다.
- 현재는 기능의 일부만 구현하였습니다. 
- 다만, 기능의 기반을 구현하였기 때문에 **전반적인 리뷰를 거치고 리팩터링하고 필요한 설정을 추가하여 정상동작이 될 수 있게 하겠습니다.**
- 현재 예상되는 PR의 순서는 `기능 구현 -> 리팩터링 -> 레디스 설정 -> 테스트 작성 -> 완료 `입니다.
### 🌱 작업 사항 
- [feat(Token): refreshToken을 전달하기 위한 응답 DTO 추가](https://github.com/prgrms-web-devcourse/Team-Kkini-Mukvengers-BE/commit/089abbcfaf19c7fe8bbe7bfada604ab5016c20d3)
  - refreshToken을 통해 새로운 accessToken을 요청했을 때 새로운 accessToken과 refreshToken 둘다 전달
  - refreshToken이 만료되지 않는 이상 계속 로그인 가능하도록 하는 방식으로 구현
- [feat(Token): RefreshToken을 통해 새로운 accessToken을 받기 위한 요청 DTO 추가](https://github.com/prgrms-web-devcourse/Team-Kkini-Mukvengers-BE/commit/b402b5dce406545c0ea9c0199c601e18e3baac1f)
- [feat(Token): refresh을 저장하기 위한 Token 객체](https://github.com/prgrms-web-devcourse/Team-Kkini-Mukvengers-BE/commit/6a90d6f3ece9c6b123dcbe006b44defe17a14b54)
- [feat(Token): TokenRepository 인터페이스 구현](https://github.com/prgrms-web-devcourse/Team-Kkini-Mukvengers-BE/commit/ac2f3d4267624852d5a650a7c0ba82f26dc5e798)
  - ID가 Long이 아닌 String인 이유는 ID를 refreshToken으로 두어 찾기 위함입니다.
  - 레디스를 적용하게 된다면 키 밸류 쌍으로 사용할 수 있습니다.
- [feat(Token): TokenService 구현](https://github.com/prgrms-web-devcourse/Team-Kkini-Mukvengers-BE/commit/bdb782939ba89ff88731c1b2329b8eceaa4b5773)
  - createToken: 새로운 토근을 발급하는 기능(access와 refresh 둘다)
  - renewTokens: 기존 토큰을 만료시키고 새롭게 만든 토근을 반환 (refresh을 통해 만료된 access토큰을 새롭게 갱신하려고 할때 동작)
  - deleteTokenByUserId: refreshToken을 만료시키는 기능(로그아웃), 추후에 oauth와 연동시킬 예정(oauth와 연동하지 않으면 oauth 로그인 요청시 자동 로그인이 됨)
- [feat(Token): TokeController 구현](https://github.com/prgrms-web-devcourse/Team-Kkini-Mukvengers-BE/commit/31d32aed2bca834a589c3666a42ee4ec560f1552)
  - Token 관련 기능을 담당하는 Api
  - 갱신 요청과 삭제 요청
- [feat(Token): RefreshTokenNotFoundException 추가](https://github.com/prgrms-web-devcourse/Team-Kkini-Mukvengers-BE/commit/27b1d7e4762ab1c466f7cdb1907c9db52cb3ec0a)
  - Refresh 토큰이 만료되어 DB에서 찾지 못할때 발생하는 예외 
- [refactor(OAuth): OAuthService login 기능에 refresh 토큰 추가](https://github.com/prgrms-web-devcourse/Team-Kkini-Mukvengers-BE/commit/ed398078f300cee103f6efc919e255a6f1dc6203)
  - 기존에 바로 accessToken을 반환하는 것에서 새로운 AuthUserInfo(DTO)를 반환
  - 토큰 생성에 대한 기능 분리
- [refactor(OAuth): OAuthSuccessHandler에서 응답시에 refreshToken도 같이 반환할 수 있도…](https://github.com/prgrms-web-devcourse/Team-Kkini-Mukvengers-BE/commit/9ef4eb4b5c7a0130f9c997615ffaca7e8960a4a3) 
  - refreshToken은 쿠키에 담아서 응답
  - 로그인 기능과 토큰 생성 기능을 분리
- [feat(Jwt): RefreshToken 생성 기능 추가](https://github.com/prgrms-web-devcourse/Team-Kkini-Mukvengers-BE/commit/5171bbc671dabc29c8959355dc02ee482bad2113) 
  - 현재는 refreshToken을 UUID로 설정
### ❓ 리뷰 포인트
- DTO 네이밍에 문제가 없나요?
- Token 객체 명을 현재는 Token으로 했는데 이대로가 나을까요 아니면 RefreshToken이 좋을까요?
- refreshToken으로 무엇을 사용하면 좋을까요? (JWT, UUID)
- refreshToken을 다양한 방식으로 할 수 있는데 어떻게 하는게 좋을까요..? 
  - 예시로 하나의 토큰을 사용하면 특정 기간을 가짐
  - 새로운 accessToken 요청시에 새로운 accessToken과 함께 새로운 refreshToken을 반환(현재 방식)
  - 등등이 있습니다. 보안상 장단점이 있습니다 어떤 방식으로 하면 좋겠다하는 의견이 있나요..?
- 전체적인 네이밍,등의 컨벤션
- 기능을 잘 나눴는지, 가독성이 좋은지, 잘 모르는 사항에 대해 리뷰 부탁드립니다.
- 해당 기능의 플로우를 팀원들 모두 어느정도는 이해할 수 있었으면 좋겠습니다~!
### 🦄 관련 이슈
#38 



