### PR TITLE
[#38] RefreshToken 기능에 Redis 적용

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -54,6 +54,7 @@ dependencies {
     testImplementation 'org.springframework.security:spring-security-test'
     // DB
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     // Test & Config
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
@@ -81,7 +82,7 @@ dependencies {
     // MapStruct
     implementation 'org.mapstruct:mapstruct:1.5.3.Final'
     annotationProcessor 'org.mapstruct:mapstruct-processor:1.5.3.Final'
-    // p6spy
+    // P6spy
     implementation 'com.github.gavlyukovskiy:p6spy-spring-boot-starter:1.8.1'
 
     // https://mvnrepository.com/artifact/org.hibernate/hibernate-spatial

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,14 @@ services:
       - ./mysqldata:/var/lib/mysql
     restart: always
 
+  redis:
+    container_name: kkini-redis
+    image: redis
+    ports:
+      - "6379:6379"
+    volumes:
+      - ./data/redis:/data
+
   web:
     container_name: web
     image: kiseo/kkini

--- a/src/main/java/com/prgrms/mukvengers/global/config/redis/RedisConfig.java
+++ b/src/main/java/com/prgrms/mukvengers/global/config/redis/RedisConfig.java
@@ -1,0 +1,32 @@
+package com.prgrms.mukvengers.global.config.redis;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+public class RedisConfig {
+
+	@Value("${spring.redis.host}")
+	private String redisHost;
+
+	@Value("${spring.redis.port}")
+	private int redisPort;
+
+	@Bean
+	public RedisConnectionFactory redisConnectionFactory() {
+		return new LettuceConnectionFactory(redisHost, redisPort);
+	}
+
+	@Bean
+	public StringRedisTemplate stringRedisTemplate() {
+		StringRedisTemplate stringRedisTemplate = new StringRedisTemplate();
+		stringRedisTemplate.setConnectionFactory(redisConnectionFactory());
+		stringRedisTemplate.setDefaultSerializer(new StringRedisSerializer()); // redis-cli을 통해 데이터 확인시에 편리하게 하기 위함
+		return stringRedisTemplate;
+	}
+}

--- a/src/main/java/com/prgrms/mukvengers/global/security/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/prgrms/mukvengers/global/security/jwt/JwtTokenProvider.java
@@ -24,14 +24,18 @@ public class JwtTokenProvider {
 	private final String issuer;
 	private final String secretKey;
 	private final long accessTokenExpirySeconds;
+	private final long refreshTokenExpirySeconds;
 
 	public JwtTokenProvider(
 		@Value("${jwt.issuer}") String issuer,
 		@Value("${jwt.secret-key}") String secretKey,
-		@Value("${jwt.expiry-seconds.access-token}") long accessTokenExpirySeconds) {
+		@Value("${jwt.expiry-seconds.access-token}") long accessTokenExpirySeconds,
+		@Value("${jwt.expiry-seconds.refresh-token}") long refreshTokenExpirySeconds
+	) {
 		this.issuer = issuer;
 		this.secretKey = secretKey;
 		this.accessTokenExpirySeconds = accessTokenExpirySeconds;
+		this.refreshTokenExpirySeconds = refreshTokenExpirySeconds;
 	}
 
 	public String createAccessToken(Long userId, String role) {

--- a/src/main/java/com/prgrms/mukvengers/global/security/token/model/RefreshToken.java
+++ b/src/main/java/com/prgrms/mukvengers/global/security/token/model/RefreshToken.java
@@ -1,0 +1,55 @@
+package com.prgrms.mukvengers.global.security.token.model;
+
+import static lombok.AccessLevel.*;
+
+import java.util.Objects;
+
+import org.springframework.data.annotation.Id;
+import org.springframework.data.redis.core.RedisHash;
+import org.springframework.data.redis.core.TimeToLive;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = PROTECTED)
+@RedisHash(value = "refreshToken")
+public class RefreshToken {
+
+	@Id
+	private String refreshToken;
+
+	private Long userId;
+
+	@TimeToLive
+	private long expiration;
+
+	@Builder
+	public RefreshToken(String refreshToken, Long userId, long expiration) {
+		this.refreshToken = checkRefreshToken(refreshToken);
+		this.userId = checkUserId(userId);
+		this.expiration = checkExpiration(expiration);
+	}
+
+	private String checkRefreshToken(String refreshToken) {
+		if (!Objects.nonNull(refreshToken) || refreshToken.isBlank()) {
+			throw new IllegalArgumentException("올바르지 않은 토큰 값");
+		}
+		return refreshToken;
+	}
+
+	private Long checkUserId(Long userId) {
+		if (!Objects.nonNull(userId) || userId < 1) {
+			throw new IllegalArgumentException("올바르지 않은 유저 아이디");
+		}
+		return userId;
+	}
+
+	private long checkExpiration(long expiration) {
+		if (expiration < 1) {
+			throw new IllegalArgumentException("올바르지 않은 만료 시간");
+		}
+		return expiration;
+	}
+}

--- a/src/main/java/com/prgrms/mukvengers/global/security/token/repository/RefreshTokenRepository.java
+++ b/src/main/java/com/prgrms/mukvengers/global/security/token/repository/RefreshTokenRepository.java
@@ -1,0 +1,8 @@
+package com.prgrms.mukvengers.global.security.token.repository;
+
+import org.springframework.data.repository.CrudRepository;
+
+import com.prgrms.mukvengers.global.security.token.model.RefreshToken;
+
+public interface RefreshTokenRepository extends CrudRepository<RefreshToken, String> {
+}

--- a/src/main/resources/application-db.yml
+++ b/src/main/resources/application-db.yml
@@ -28,10 +28,15 @@ spring:
         dialect: org.hibernate.spatial.dialect.mysql.MySQL8SpatialDialect
         format_sql: true
 
-    # flyway 설정
+  # flyway 설정
   flyway:
     enabled: true
     baseline-on-migrate: true
+
+  # redis
+  redis:
+    host: ${REDIS_HOST}
+    port: ${REDIS_PORT}
 
 --- # local
 spring:

--- a/src/main/resources/application-security.yml
+++ b/src/main/resources/application-security.yml
@@ -4,6 +4,7 @@ jwt:
   secret-key: ${JWT_SECRET_KEY}
   expiry-seconds:
     access-token: 3600
+    refresh-token: 360000
 
 # OAuth 2.0 설정
 spring:

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -8,6 +8,10 @@ spring:
     username: root
     password: team-kkini
 
+  redis:
+    host: localhost
+    port: 6379
+
   jpa:
     database: mysql
     generate-ddl: false

--- a/src/test/java/com/prgrms/mukvengers/config/JwtConfig.java
+++ b/src/test/java/com/prgrms/mukvengers/config/JwtConfig.java
@@ -13,8 +13,9 @@ public class JwtConfig {
 	public JwtTokenProvider jwtTokenProvider(
 		@Value("${jwt.issuer}") String issuer,
 		@Value("${jwt.secret-key}") String secretKey,
-		@Value("${jwt.expiry-seconds.access-token}") int accessTokenExpirySeconds
+		@Value("${jwt.expiry-seconds.access-token}") long accessTokenExpirySeconds,
+		@Value("${jwt.expiry-seconds.refresh-token}") long refreshTokenExpirySeconds
 	) {
-		return new JwtTokenProvider(issuer, secretKey, accessTokenExpirySeconds);
+		return new JwtTokenProvider(issuer, secretKey, accessTokenExpirySeconds, refreshTokenExpirySeconds);
 	}
 }

--- a/src/test/java/com/prgrms/mukvengers/global/security/jwt/JwtAuthenticationFilterTest.java
+++ b/src/test/java/com/prgrms/mukvengers/global/security/jwt/JwtAuthenticationFilterTest.java
@@ -26,7 +26,8 @@ class JwtAuthenticationFilterTest {
 	private static final String BEARER_TYPE = "Bearer ";
 	private static final String ISSUER = "issuer";
 	private static final String SECRET_KEY = "kkini-team-kkini-project-fighting";
-	private static final int ACCESS_TOKEN_EXPIRY_SECONDS = 3;
+	private static final long ACCESS_TOKEN_EXPIRY_SECONDS = 3L;
+	private static final long REFRESH_TOKEN_EXPIRY_SECONDS = 5L;
 	private static final String USER_ROLE = "USER";
 
 	private JwtAuthenticationFilter jwtAuthenticationFilter;
@@ -41,7 +42,8 @@ class JwtAuthenticationFilterTest {
 		request = new MockHttpServletRequest();
 		response = new MockHttpServletResponse();
 		filterChain = new MockFilterChain();
-		jwtTokenProvider = new JwtTokenProvider(ISSUER, SECRET_KEY, ACCESS_TOKEN_EXPIRY_SECONDS);
+		jwtTokenProvider = new JwtTokenProvider(ISSUER, SECRET_KEY, ACCESS_TOKEN_EXPIRY_SECONDS,
+			REFRESH_TOKEN_EXPIRY_SECONDS);
 		jwtAuthenticationFilter = new JwtAuthenticationFilter(jwtTokenProvider);
 		ACCESS_TOKEN = jwtTokenProvider.createAccessToken(USER_ID, USER_ROLE);
 	}
@@ -98,7 +100,7 @@ class JwtAuthenticationFilterTest {
 	@DisplayName("[실패] 만료된 토큰일 경우 예외를 발생한다.")
 	void doFilterInternal_ExpiredToken_fail() {
 		// given
-		JwtTokenProvider jwtTokenProvider = new JwtTokenProvider(ISSUER, SECRET_KEY, 0);
+		JwtTokenProvider jwtTokenProvider = new JwtTokenProvider(ISSUER, SECRET_KEY, 0, 3);
 
 		String newToken = jwtTokenProvider.createAccessToken(USER_ID, USER_ROLE);
 

--- a/src/test/java/com/prgrms/mukvengers/global/security/jwt/JwtTokenProviderTest.java
+++ b/src/test/java/com/prgrms/mukvengers/global/security/jwt/JwtTokenProviderTest.java
@@ -17,10 +17,11 @@ class JwtTokenProviderTest {
 	private static final String ISSUER = "issuer";
 	private static final String SECRET_KEY = "kkini-team-kkini-project-fighting";
 	private static final int ACCESS_TOKEN_EXPIRY_SECONDS = 1;
+	private static final long REFRESH_TOKEN_EXPIRY_SECONDS = 5L;
 	private static final String USER_ROLE = "USER";
 
 	private final JwtTokenProvider jwtTokenProvider
-		= new JwtTokenProvider(ISSUER, SECRET_KEY, ACCESS_TOKEN_EXPIRY_SECONDS);
+		= new JwtTokenProvider(ISSUER, SECRET_KEY, ACCESS_TOKEN_EXPIRY_SECONDS, REFRESH_TOKEN_EXPIRY_SECONDS);
 
 	private String accessToken;
 
@@ -98,7 +99,8 @@ class JwtTokenProviderTest {
 		String invalidIssuer = "wrong-issuer";
 
 		JwtTokenProvider wongTokenProvider
-			= new JwtTokenProvider(invalidIssuer, SECRET_KEY, ACCESS_TOKEN_EXPIRY_SECONDS);
+			= new JwtTokenProvider(invalidIssuer, SECRET_KEY, ACCESS_TOKEN_EXPIRY_SECONDS,
+			REFRESH_TOKEN_EXPIRY_SECONDS);
 		//when
 		accessToken = wongTokenProvider.createAccessToken(USER_ID, USER_ROLE);
 		//then
@@ -113,7 +115,7 @@ class JwtTokenProviderTest {
 		String invalidSecretKey = "when_the_night_comes,we_get_stronger";
 
 		JwtTokenProvider wongTokenProvider
-			= new JwtTokenProvider(ISSUER, invalidSecretKey, ACCESS_TOKEN_EXPIRY_SECONDS);
+			= new JwtTokenProvider(ISSUER, invalidSecretKey, ACCESS_TOKEN_EXPIRY_SECONDS, REFRESH_TOKEN_EXPIRY_SECONDS);
 		//when
 		accessToken = wongTokenProvider.createAccessToken(USER_ID, USER_ROLE);
 		//then


### PR DESCRIPTION
### 🌱 작업 사항 
- [feat(Redis): 레디스 의존성 추가](https://github.com/prgrms-web-devcourse/Team-Kkini-Mukvengers-BE/commit/1d29cb502f16c4a7988fd82bb1c065ebe39b75f7)
  - 스프링 부트에서 제공하는 `spring-boot-starter-data-redis` 사용
- [feat(Redis): 레디스 host 및 port 설정](https://github.com/prgrms-web-devcourse/Team-Kkini-Mukvengers-BE/commit/4175e084e7bec1bbd29eb8d99e3adb4ae88ba90a)
  - 프러덕션 코드는 `host`와 `port`를 환경 변수로 관리
  - 테스트는 localhost로 사용하고 port는 디폴트 포트인 **6379**로 사용
  - 실행시키기 위해서는 도커로 레디스를 설치해야 합니다
- [feat(Token): RefreshToken 만료 시간 설정](https://github.com/prgrms-web-devcourse/Team-Kkini-Mukvengers-BE/commit/5eff9c30fa250efbce114a8d2003b91ab07fb944)
  - `360000초`(100시간)로 설정
- [feat(Token): JwtTokenProviderdp RefreshToken 만료 시간 추가](https://github.com/prgrms-web-devcourse/Team-Kkini-Mukvengers-BE/commit/69722988a483681b4ef086551afe723f994053f8)
  - JwtTokenProvider에서 토큰 만료시간 관리
- [feat(Token): RefreshToken 객체 추가](https://github.com/prgrms-web-devcourse/Team-Kkini-Mukvengers-BE/commit/b8b3b479df3431cdfa3953eab3e1d67e7f5c8c27)
  - **`기존에 만든 Token과 합칠 생각입니다`**
  - 레디스에 저장하기 위해 만든 Entity입니다
- [feat(Token): RefreshTokenRepository 추가](https://github.com/prgrms-web-devcourse/Team-Kkini-Mukvengers-BE/commit/342b0bf44f15fc0a7e21e88cea0c00409a6e0f15)
  - 레디스에 저장하기 위해 사용하는 Repository
  - `Repository`를 이용하는 방법과 `RedisTemplate`를 이용하는 방법이 있지만 현재 복잡한 사용이 요구되지 않음으로 간단한 CRUD가 가능한 `CrudRepository`를 사용했습니다
- [feat(Token): RedisConfig 추가](https://github.com/prgrms-web-devcourse/Team-Kkini-Mukvengers-BE/commit/b9109d331ae8f40943d58d6c17cc3fc6cb7ad8af)
  - 권장되는 기본 구현체인 `Lettuce` 사용
  - 추후에 `RedisTemplate`를 이용해 복잡한 작업도 진행할 수 있기 때문에 일단 Bean에 등록했습니다
### ❓ 리뷰 포인트
- 저도 Redis를 처음 사용해봐서 정확하진 않을 수 있습니다! 그래도 모르는게 있다면 물어봐주세요
### 🦄 관련 이슈
#38



