### PR TITLE
[#65] 사용자의 밥 모임 조회

### DIFF
--- a/src/main/java/com/prgrms/mukvengers/domain/crew/api/CrewController.java
+++ b/src/main/java/com/prgrms/mukvengers/domain/crew/api/CrewController.java
@@ -27,6 +27,7 @@ import com.prgrms.mukvengers.domain.crew.dto.request.UpdateStatusRequest;
 import com.prgrms.mukvengers.domain.crew.dto.response.CrewPageResponse;
 import com.prgrms.mukvengers.domain.crew.dto.response.CrewResponse;
 import com.prgrms.mukvengers.domain.crew.dto.response.CrewResponses;
+import com.prgrms.mukvengers.domain.crew.dto.response.MyCrewResponse;
 import com.prgrms.mukvengers.domain.crew.service.CrewService;
 import com.prgrms.mukvengers.global.common.dto.ApiResponse;
 import com.prgrms.mukvengers.global.common.dto.IdResponse;
@@ -75,6 +76,14 @@ public class CrewController {
 	) {
 		CrewResponse response = crewService.getById(crewId);
 		return ResponseEntity.ok().body(new ApiResponse<>(response));
+	}
+
+	@GetMapping(value = "/me", produces = APPLICATION_JSON_VALUE)
+	public ResponseEntity<ApiResponse<MyCrewResponse>> getByUserId(
+		@AuthenticationPrincipal JwtAuthentication user
+	) {
+		MyCrewResponse responses = crewService.getByUserId(user.id());
+		return ResponseEntity.ok().body(new ApiResponse<>(responses));
 	}
 
 	/**

--- a/src/main/java/com/prgrms/mukvengers/domain/crew/dto/response/CrewResponse.java
+++ b/src/main/java/com/prgrms/mukvengers/domain/crew/dto/response/CrewResponse.java
@@ -5,6 +5,7 @@ import java.time.LocalDateTime;
 public record CrewResponse(
 	Long id,
 	String name,
+	Integer currentMember,
 	Integer capacity,
 	String status,
 	String content,

--- a/src/main/java/com/prgrms/mukvengers/domain/crew/dto/response/MyCrewResponse.java
+++ b/src/main/java/com/prgrms/mukvengers/domain/crew/dto/response/MyCrewResponse.java
@@ -1,0 +1,9 @@
+package com.prgrms.mukvengers.domain.crew.dto.response;
+
+import java.util.List;
+
+public record MyCrewResponse(
+	List<CrewResponse> responses,
+	String profileImgUrl
+) {
+}

--- a/src/main/java/com/prgrms/mukvengers/domain/crew/mapper/CrewMapper.java
+++ b/src/main/java/com/prgrms/mukvengers/domain/crew/mapper/CrewMapper.java
@@ -23,7 +23,7 @@ public interface CrewMapper {
 	Crew toCrew(CreateCrewRequest createCrewRequest, Store store);
 
 	@Mapping(target = "promiseTime", source = "crew.promiseTime")
-	CrewResponse toCrewResponse(Crew crew);
+	CrewResponse toCrewResponse(Crew crew, Integer currentMember);
 
 	@Named("statusMethod")
 	default Status mapStatus(String status) {

--- a/src/main/java/com/prgrms/mukvengers/domain/crew/service/CrewService.java
+++ b/src/main/java/com/prgrms/mukvengers/domain/crew/service/CrewService.java
@@ -8,11 +8,14 @@ import com.prgrms.mukvengers.domain.crew.dto.request.UpdateStatusRequest;
 import com.prgrms.mukvengers.domain.crew.dto.response.CrewPageResponse;
 import com.prgrms.mukvengers.domain.crew.dto.response.CrewResponse;
 import com.prgrms.mukvengers.domain.crew.dto.response.CrewResponses;
+import com.prgrms.mukvengers.domain.crew.dto.response.MyCrewResponse;
 import com.prgrms.mukvengers.global.common.dto.IdResponse;
 
 public interface CrewService {
 
 	IdResponse create(CreateCrewRequest createCrewRequest, Long userId);
+
+	MyCrewResponse getByUserId(Long userId);
 
 	CrewResponse getById(Long crewId);
 

--- a/src/main/java/com/prgrms/mukvengers/domain/crewmember/repository/CrewMemberRepository.java
+++ b/src/main/java/com/prgrms/mukvengers/domain/crewmember/repository/CrewMemberRepository.java
@@ -1,11 +1,13 @@
 package com.prgrms.mukvengers.domain.crewmember.repository;
 
+import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import com.prgrms.mukvengers.domain.crew.model.Crew;
 import com.prgrms.mukvengers.domain.crewmember.model.CrewMember;
 
 public interface CrewMemberRepository extends JpaRepository<CrewMember, Long> {
@@ -15,5 +17,19 @@ public interface CrewMemberRepository extends JpaRepository<CrewMember, Long> {
 		FROM CrewMember cm
 		WHERE cm.crew.id= :crewId AND cm.userId= :revieweeId
 		""")
-	Optional<CrewMember> findCrewMemberByCrewIdAndUserId(@Param(value = "crewId") Long crewId, @Param(value = "revieweeId") Long revieweeId);
+	Optional<CrewMember> findCrewMemberByCrewIdAndUserId(@Param(value = "crewId") Long crewId,
+		@Param(value = "revieweeId") Long revieweeId);
+
+	@Query(value = """
+		SELECT cm.crew
+		FROM CrewMember cm
+		WHERE cm.userId = :userId
+		ORDER BY CASE WHEN cm.crew.status = 'RECRUITING' THEN 0
+					  WHEN cm.crew.status = 'CLOSE' THEN 1
+					  ELSE 2 END
+		""")
+	List<Crew> findAllByUserIdOrderByStatus(@Param("userId") Long userId);
+
+	Integer countCrewMemberByCrewId(@Param(value = "crewId") Long crewId);
+
 }

--- a/src/test/java/com/prgrms/mukvengers/base/ServiceTest.java
+++ b/src/test/java/com/prgrms/mukvengers/base/ServiceTest.java
@@ -11,6 +11,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.prgrms.mukvengers.domain.crew.repository.CrewRepository;
 import com.prgrms.mukvengers.domain.crew.service.CrewService;
+import com.prgrms.mukvengers.domain.crewmember.repository.CrewMemberRepository;
 import com.prgrms.mukvengers.domain.review.repository.ReviewRepository;
 import com.prgrms.mukvengers.domain.review.service.ReviewService;
 import com.prgrms.mukvengers.domain.store.model.Store;
@@ -41,6 +42,9 @@ public abstract class ServiceTest {
 
 	@Autowired
 	protected CrewRepository crewRepository;
+
+	@Autowired
+	protected CrewMemberRepository crewMemberRepository;
 
 	@Autowired
 	protected ReviewService reviewService;

--- a/src/test/java/com/prgrms/mukvengers/domain/crew/service/CrewServiceImplTest.java
+++ b/src/test/java/com/prgrms/mukvengers/domain/crew/service/CrewServiceImplTest.java
@@ -1,5 +1,8 @@
 package com.prgrms.mukvengers.domain.crew.service;
 
+import static com.prgrms.mukvengers.domain.crew.model.vo.Status.*;
+import static com.prgrms.mukvengers.utils.CrewMemberObjectProvider.*;
+import static com.prgrms.mukvengers.utils.CrewObjectProvider.*;
 import static org.assertj.core.api.Assertions.*;
 
 import java.util.List;
@@ -20,9 +23,11 @@ import com.prgrms.mukvengers.domain.crew.dto.request.UpdateStatusRequest;
 import com.prgrms.mukvengers.domain.crew.dto.response.CrewPageResponse;
 import com.prgrms.mukvengers.domain.crew.dto.response.CrewResponse;
 import com.prgrms.mukvengers.domain.crew.dto.response.CrewResponses;
+import com.prgrms.mukvengers.domain.crew.dto.response.MyCrewResponse;
 import com.prgrms.mukvengers.domain.crew.model.Crew;
 import com.prgrms.mukvengers.domain.crew.model.vo.Category;
-import com.prgrms.mukvengers.domain.crew.model.vo.Status;
+import com.prgrms.mukvengers.domain.crewmember.model.CrewMember;
+import com.prgrms.mukvengers.domain.crewmember.model.vo.Role;
 import com.prgrms.mukvengers.global.common.dto.IdResponse;
 import com.prgrms.mukvengers.utils.CrewObjectProvider;
 
@@ -52,9 +57,26 @@ class CrewServiceImplTest extends ServiceTest {
 			.hasFieldOrPropertyWithValue("name", createCrewRequest.name())
 			.hasFieldOrPropertyWithValue("location", location)
 			.hasFieldOrPropertyWithValue("capacity", createCrewRequest.capacity())
-			.hasFieldOrPropertyWithValue("status", Status.of(createCrewRequest.status()))
+			.hasFieldOrPropertyWithValue("status", of(createCrewRequest.status()))
 			.hasFieldOrPropertyWithValue("content", createCrewRequest.content())
 			.hasFieldOrPropertyWithValue("category", Category.of(createCrewRequest.category()));
+	}
+
+	@Test
+	@DisplayName("[성공] 유저 아이디로 유저가 참여한 Crew를 조회한다.")
+	void getByUserId_success() {
+
+		List<Crew> crews = createCrews(savedStore);
+		crewRepository.saveAll(crews);
+
+		crews.forEach(crew -> {
+			CrewMember crewMember = createCrewMember(savedUserId, crew, Role.MEMBER);
+			crewMemberRepository.save(crewMember);
+		});
+
+		MyCrewResponse responses = crewService.getByUserId(savedUserId);
+		assertThat(responses.responses()).hasSize(crews.size());
+		assertThat(responses.profileImgUrl()).isEqualTo(savedUser.getProfileImgUrl());
 	}
 
 	@Test
@@ -62,7 +84,7 @@ class CrewServiceImplTest extends ServiceTest {
 	void getById_success() {
 
 		//given
-		Crew crew = CrewObjectProvider.createCrew(savedStore);
+		Crew crew = CrewObjectProvider.createCrew(savedStore, RECRUITING);
 
 		crewRepository.save(crew);
 
@@ -107,7 +129,7 @@ class CrewServiceImplTest extends ServiceTest {
 	void findByLocation_success() {
 
 		//given
-		Crew crew = CrewObjectProvider.createCrew(savedStore);
+		Crew crew = CrewObjectProvider.createCrew(savedStore, RECRUITING);
 
 		crewRepository.save(crew);
 
@@ -131,7 +153,7 @@ class CrewServiceImplTest extends ServiceTest {
 	void updateStatus_success() {
 
 		//given
-		Crew crew = CrewObjectProvider.createCrew(savedStore);
+		Crew crew = CrewObjectProvider.createCrew(savedStore, RECRUITING);
 
 		crewRepository.save(crew);
 
@@ -146,7 +168,7 @@ class CrewServiceImplTest extends ServiceTest {
 
 		assertThat(optionalCrew).isPresent();
 		Crew savedCrew = optionalCrew.get();
-		assertThat(savedCrew.getStatus()).isEqualTo(Status.of(status));
+		assertThat(savedCrew.getStatus()).isEqualTo(of(status));
 	}
 
 }

--- a/src/test/java/com/prgrms/mukvengers/domain/crewmember/repository/CrewMemberRepositoryTest.java
+++ b/src/test/java/com/prgrms/mukvengers/domain/crewmember/repository/CrewMemberRepositoryTest.java
@@ -1,5 +1,6 @@
 package com.prgrms.mukvengers.domain.crewmember.repository;
 
+import static com.prgrms.mukvengers.domain.crew.model.vo.Status.*;
 import static com.prgrms.mukvengers.utils.CrewMemberObjectProvider.*;
 import static com.prgrms.mukvengers.utils.CrewObjectProvider.*;
 import static com.prgrms.mukvengers.utils.UserObjectProvider.*;
@@ -27,7 +28,7 @@ class CrewMemberRepositoryTest extends RepositoryTest {
 	void setCrewMember() {
 		reviewer = savedUser;
 		reviewee = userRepository.save(createUser("kakao_1212"));
-		crew = crewRepository.save(createCrew(savedStore));
+		crew = crewRepository.save(createCrew(savedStore, RECRUITING));
 	}
 
 	@Test
@@ -68,7 +69,7 @@ class CrewMemberRepositoryTest extends RepositoryTest {
 	@DisplayName("[실패] 해당 밥모임에 참여하지 않은 사용자이면 empty 반환된다.")
 	void findCrewMemberByCrewIdAndUserId_success() {
 		// given
-		Crew otherCrew = crewRepository.save(createCrew(savedStore));
+		Crew otherCrew = crewRepository.save(createCrew(savedStore, RECRUITING));
 		CrewMember crewMemberOfMember = createCrewMember(reviewee.getId(), otherCrew, Role.MEMBER);
 		CrewMember member = crewMemberRepository.save(crewMemberOfMember);
 		otherCrew.addCrewMember(member);

--- a/src/test/java/com/prgrms/mukvengers/domain/review/api/ReviewControllerTest.java
+++ b/src/test/java/com/prgrms/mukvengers/domain/review/api/ReviewControllerTest.java
@@ -3,6 +3,7 @@ package com.prgrms.mukvengers.domain.review.api;
 import static com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper.*;
 import static com.epages.restdocs.apispec.ResourceDocumentation.*;
 import static com.epages.restdocs.apispec.ResourceSnippetParameters.*;
+import static com.prgrms.mukvengers.domain.crew.model.vo.Status.*;
 import static com.prgrms.mukvengers.utils.CrewMemberObjectProvider.*;
 import static com.prgrms.mukvengers.utils.CrewObjectProvider.*;
 import static com.prgrms.mukvengers.utils.ReviewObjectProvider.*;
@@ -47,7 +48,7 @@ class ReviewControllerTest extends ControllerTest {
 	void setCrew() {
 		reviewer = savedUser;
 		reviewee = userRepository.save(createUser("kakao_1212"));
-		crew = crewRepository.save(createCrew(savedStore));
+		crew = crewRepository.save(createCrew(savedStore, RECRUITING));
 
 		crewMemberOfReviewer = crewMemberRepository.save(
 			createCrewMember(reviewer.getId(), crew, Role.MEMBER));
@@ -158,6 +159,7 @@ class ReviewControllerTest extends ControllerTest {
 							fieldWithPath("data.reviewee.tasteScore").type(NUMBER).description("리뷰이의 맛잘알 점수"),
 							fieldWithPath("data.reviewee.mannerScore").type(NUMBER).description("리뷰이의 매너 점수"),
 
+							fieldWithPath("data.crew.currentMember").type(NULL).description("밥모임의 아이디"),
 							fieldWithPath("data.crew.id").type(NUMBER).description("밥모임의 아이디"),
 							fieldWithPath("data.crew.name").type(STRING).description("밥모임의 이름"),
 							fieldWithPath("data.crew.capacity").type(NUMBER).description("밥모임의 정원"),

--- a/src/test/java/com/prgrms/mukvengers/domain/review/service/ReviewServiceImplTest.java
+++ b/src/test/java/com/prgrms/mukvengers/domain/review/service/ReviewServiceImplTest.java
@@ -1,5 +1,6 @@
 package com.prgrms.mukvengers.domain.review.service;
 
+import static com.prgrms.mukvengers.domain.crew.model.vo.Status.*;
 import static com.prgrms.mukvengers.utils.CrewObjectProvider.*;
 import static com.prgrms.mukvengers.utils.ReviewObjectProvider.*;
 import static com.prgrms.mukvengers.utils.UserObjectProvider.*;
@@ -38,7 +39,7 @@ class ReviewServiceImplTest extends ServiceTest {
 	void setReview() {
 		reviewer = savedUser;
 		reviewee = userRepository.save(createUser("kakao_1212"));
-		crew = crewRepository.save(createCrew(savedStore));
+		crew = crewRepository.save(createCrew(savedStore, RECRUITING));
 	}
 
 	@Test

--- a/src/test/java/com/prgrms/mukvengers/utils/CrewObjectProvider.java
+++ b/src/test/java/com/prgrms/mukvengers/utils/CrewObjectProvider.java
@@ -25,33 +25,31 @@ public class CrewObjectProvider {
 	private static final String LONGITUDE = "-147.4654321321";
 	private static final String NAME = "원정대이름";
 	private static final Integer CAPACITY = 5;
-	private static final Status STATUS = RECRUITING;
+	private static final Status STATUS_RECRUITING = RECRUITING;
+	private static final Status STATUS_CLOSE = CLOSE;
 	private static final String CONTENT = "저는 백엔드 개발자 입니다. 프론트 엔드 개발자 구해요";
 	private static final Category CATEGORY = QUIET;
 	private static final LocalDateTime PROMISE_TIME = LocalDateTime.now();
 	private static final Point LOCATION = GF.createPoint(
 		new Coordinate(Double.parseDouble(LONGITUDE), Double.parseDouble(LATITUDE)));
 
-	public static Crew createCrew(Store store) {
-
+	public static Crew createCrew(Store store, Status status) {
 		return Crew.builder()
 			.store(store)
 			.name(NAME)
 			.location(LOCATION)
 			.promiseTime(PROMISE_TIME)
 			.capacity(CAPACITY)
-			.status(STATUS)
+			.status(status)
 			.content(CONTENT)
 			.category(CATEGORY)
 			.build();
-
 	}
 
 	public static List<Crew> createCrews(Store store) {
-
 		return IntStream.range(0, 20)
-			.mapToObj(i -> createCrew(store)).collect(Collectors.toList());
-
+			.mapToObj(i -> createCrew(store, i % 2 == 0 ? STATUS_CLOSE : STATUS_RECRUITING))
+			.collect(Collectors.toList());
 	}
 
 	public static CreateCrewRequest getCreateCrewRequest(String mapStoreId) {
@@ -62,7 +60,7 @@ public class CrewObjectProvider {
 			LATITUDE,
 			PROMISE_TIME,
 			CAPACITY,
-			STATUS.getStatus(),
+			STATUS_RECRUITING.getStatus(),
 			CONTENT,
 			CATEGORY.getCategory()
 		);


### PR DESCRIPTION
### 🌱 작업 사항 
- 사용자가 참여한 모든 모임 조회 기능 구현, 테스트
- 프런트의 요청 사항으로 현재인원을 조회하기 위해 모임원 Repository에서 모임 아이디로 조회를 하여 현재인원을 count 하여 리턴합니다.
- 프런트의 요청으로 조회된 모임을 모집 중인 데이터를 먼저 오게 정렬하고 모집 종료된 모임이 나중에 오도록 정렬합니다.
- 프런트의 요청으로 현재 사용자의 프로필 이미지도 리턴합니다.
- CrewResponse에서 현재인원 필드 추가하였습니다.
- 
### ❓ 리뷰 포인트
- 프론트의 요청으로 이미지 URL을 리턴해주어야 되서 새로운 응답 DTO MyCrewResponse를 만들었습니다.
- 이 DTO 네이밍이 어떠신지 궁금합니다.
- 
### 🦄 관련 이슈
resolves #65 



