### PR TITLE
[#77] 사용자 프로필 이미지를 S3에 저장한다.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -89,6 +89,9 @@ dependencies {
     implementation 'org.hibernate:hibernate-spatial'
     //https://mvnrepository.com/artifact/org.locationtech.jts/jts-core
     implementation 'org.locationtech.jts:jts-core:1.19.0'
+
+    // AWS
+    implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
 }
 
 

--- a/src/main/java/com/prgrms/mukvengers/global/aws/api/AwsS3Controller.java
+++ b/src/main/java/com/prgrms/mukvengers/global/aws/api/AwsS3Controller.java
@@ -1,0 +1,35 @@
+package com.prgrms.mukvengers.global.aws.api;
+
+import static org.springframework.http.MediaType.*;
+
+import java.io.IOException;
+
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
+import com.prgrms.mukvengers.global.aws.dto.AwsS3;
+import com.prgrms.mukvengers.global.aws.service.AwsS3Service;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/s3")
+public class AwsS3Controller {
+
+	private final AwsS3Service awsS3Service;
+
+	@PostMapping(value = "/resource", consumes = MULTIPART_FORM_DATA_VALUE)
+	public AwsS3 upload(@RequestPart("file") MultipartFile multipartFile) throws IOException {
+		return awsS3Service.upload(multipartFile, "profile");
+	}
+
+	@DeleteMapping("/resource")
+	public void remove(AwsS3 awsS3) {
+		awsS3Service.remove(awsS3);
+	}
+}

--- a/src/main/java/com/prgrms/mukvengers/global/aws/dto/AwsS3.java
+++ b/src/main/java/com/prgrms/mukvengers/global/aws/dto/AwsS3.java
@@ -1,0 +1,20 @@
+package com.prgrms.mukvengers.global.aws.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class AwsS3 {
+	private String key;
+	private String path;
+
+	@Builder
+	protected AwsS3(String key, String path) {
+		this.key = key;
+		this.path = path;
+	}
+}

--- a/src/main/java/com/prgrms/mukvengers/global/aws/service/AwsS3Service.java
+++ b/src/main/java/com/prgrms/mukvengers/global/aws/service/AwsS3Service.java
@@ -1,0 +1,85 @@
+package com.prgrms.mukvengers.global.aws.service;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.util.Optional;
+import java.util.UUID;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.AmazonS3Exception;
+import com.amazonaws.services.s3.model.CannedAccessControlList;
+import com.amazonaws.services.s3.model.PutObjectRequest;
+import com.prgrms.mukvengers.global.aws.dto.AwsS3;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class AwsS3Service {
+
+	private final AmazonS3 amazonS3;
+
+	@Value("${cloud.aws.s3.bucket}")
+	private String bucket;
+
+	public AwsS3 upload(MultipartFile multipartFile, String dirName) throws IOException {
+		File file = convertMultipartFileToFile(multipartFile)
+			.orElseThrow(() -> new IllegalArgumentException("MultipartFile -> File convert fail"));
+
+		return upload(file, dirName);
+	}
+
+	private AwsS3 upload(File file, String dirName) {
+		String key = randomFileName(file, dirName);
+		String path = putS3(file, key);
+		removeFile(file);
+
+		return AwsS3
+			.builder()
+			.key(key)
+			.path(path)
+			.build();
+	}
+
+	private String randomFileName(File file, String dirName) {
+		return dirName + "/" + UUID.randomUUID() + file.getName();
+	}
+
+	private String putS3(File uploadFile, String fileName) {
+		amazonS3.putObject(new PutObjectRequest(bucket, fileName, uploadFile)
+			.withCannedAcl(CannedAccessControlList.PublicRead));
+		return getS3(bucket, fileName);
+	}
+
+	private String getS3(String bucket, String fileName) {
+		return amazonS3.getUrl(bucket, fileName).toString();
+	}
+
+	private void removeFile(File file) {
+		file.delete();
+	}
+
+	public Optional<File> convertMultipartFileToFile(MultipartFile multipartFile) throws IOException {
+		File file = new File(System.getProperty("user.dir") + "/" + multipartFile.getOriginalFilename());
+
+		if (file.createNewFile()) {
+			try (FileOutputStream fileOutputStream = new FileOutputStream(file)) {
+				fileOutputStream.write(multipartFile.getBytes());
+			}
+			return Optional.of(file);
+		}
+		return Optional.empty();
+	}
+
+	public void remove(AwsS3 awsS3) {
+		if (!amazonS3.doesObjectExist(bucket, awsS3.getKey())) {
+			throw new AmazonS3Exception("Object " + awsS3.getKey() + " does not exist");
+		}
+		amazonS3.deleteObject(bucket, awsS3.getKey());
+	}
+}

--- a/src/main/java/com/prgrms/mukvengers/global/config/s3/AwsConfig.java
+++ b/src/main/java/com/prgrms/mukvengers/global/config/s3/AwsConfig.java
@@ -1,0 +1,32 @@
+package com.prgrms.mukvengers.global.config.s3;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import com.amazonaws.auth.AWSCredentials;
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+
+@Configuration
+public class AwsConfig {
+	@Value("${cloud.aws.credentials.access-key}")
+	private String accessKey;
+
+	@Value("${cloud.aws.credentials.secret-key}")
+	private String secretKey;
+
+	@Value("${cloud.aws.region.static}")
+	private String region;
+
+	@Bean
+	public AmazonS3 amazonS3() {
+		AWSCredentials awsCredentials = new BasicAWSCredentials(accessKey, secretKey);
+		return AmazonS3ClientBuilder.standard()
+			.withRegion(region)
+			.withCredentials(new AWSStaticCredentialsProvider(awsCredentials))
+			.build();
+	}
+}

--- a/src/main/resources/application-aws.yml
+++ b/src/main/resources/application-aws.yml
@@ -1,0 +1,18 @@
+spring:
+  servlet:
+    multipart:
+      max-request-size: 10MB
+      max-file-size: 10MB
+
+cloud:
+  aws:
+    s3:
+      bucket: kkini-bucket
+    credentials:
+      access-key: ${AWS_ACCESS_KEY}
+      secret-key: ${AWS_SECRET_KEY}
+    region:
+      static: ap-northeast-2
+      auto: false
+    stack:
+      auto: false

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -15,6 +15,7 @@ spring:
     include:
       - db
       - security
+      - aws
   # ResourceHandler 설정 (Static Resource Mapping)
   web:
     resources:

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -3,3 +3,4 @@ spring:
     include:
       - test
       - security
+      - aws


### PR DESCRIPTION
@JoosungKwon  주성님이랑 같이 S3 작업하다가.. 제가 그만 git 시간여행에 실패해서... 새로운 branch를 파서 PR 날립니다..

### 🌱 작업 사항 
- `/s3/resource  POST`: 프로필 이미지를 변경하는 요청이 올 때 S3에 이미지 파일을 저장하고, S3의 URL(path)과 업로드된 이미지의 객체명(key)을 담은 AwsS3 Dto를 반환합니다.
- `/s3/resource DELETE`: 프로필 이미지를 삭제하는 요청의 경우 key값을 이용해 S3에서 이미지 파일을 삭제합니다.

### ❓ 리뷰 포인트
- 프로필 이미지 외에 다른 곳에서 S3를 사용할 수도 있다고 판단하여 
패키지 구조를 global>aws>api, service로 설정했습니다.

- `bucket`: AWS S3에서 직접 생성한 스토리지 창고 이름입니다. kkini-bucket으로 설정했으며 이곳에 저장된 이미지의 URL은 kkini-bucket으로 시작합니다. 

- S3에 업로드하기 위해서는 프론트로부터 이미지 파일을 받은 뒤(MultipartFile 타입이며 컨트롤러에서 받고 있습니다)
이를 File 객체로 변환후 현재 프로젝트 경로에 업로드 합니다. 
이후 파일명에 UUID를 붙혀서 S3에 업로드하고, 현재 경로에 생성한 File 객체를 삭제하는 과정을 거칩니다.

- 이해 안되는 부분이나 개선할 수 있는 부분 말씀해주시면 감사하겠습니다!!!

저장 요청 시 Response
![image](https://user-images.githubusercontent.com/81108344/222985897-3a181286-b0a5-4e5b-a4fb-5df90e479040.png)

### 🦄 관련 이슈
#77 

