### PR TITLE
[#89] 내가 작성한 리뷰 & 나에 대한 리뷰 API 생성

### DIFF
--- a/src/main/java/com/prgrms/mukvengers/domain/review/api/ReviewController.java
+++ b/src/main/java/com/prgrms/mukvengers/domain/review/api/ReviewController.java
@@ -75,7 +75,7 @@ public class ReviewController {
 		@AuthenticationPrincipal JwtAuthentication user
 	) {
 		IdResponse reviewIdResponse = reviewService.createMemberReview(createMemberReviewRequest, user.id(), crewId);
-		URI location = UriComponentsBuilder.fromUriString("/api/v1/posts/" + reviewIdResponse.id()).build().toUri();
+		URI location = UriComponentsBuilder.fromUriString("/api/v1/reviews/" + reviewIdResponse.id()).build().toUri();
 		return ResponseEntity.created(location).build();
 	}
 

--- a/src/main/java/com/prgrms/mukvengers/domain/review/api/ReviewController.java
+++ b/src/main/java/com/prgrms/mukvengers/domain/review/api/ReviewController.java
@@ -1,9 +1,15 @@
 package com.prgrms.mukvengers.domain.review.api;
 
+import static org.springframework.http.MediaType.*;
+
 import java.net.URI;
 
 import javax.validation.Valid;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -40,7 +46,7 @@ public class ReviewController {
 	 * @param crewId 리뷰 작성자가 참여한 모임
 	 * @return status :201, body : 생성된 리뷰 조회 redirectUri
 	 */
-	@PostMapping("/crews/{crewId}/reviews/leader")
+	@PostMapping(value = "/crews/{crewId}/reviews/leader", consumes = APPLICATION_JSON_VALUE)
 	public ResponseEntity<IdResponse> createLeaderReview
 	(
 		@PathVariable Long crewId,
@@ -61,7 +67,7 @@ public class ReviewController {
 	 * @param crewId 리뷰 작성자가 참여한 모임
 	 * @return status :201, body : 생성된 리뷰 조회 redirectUri
 	 */
-	@PostMapping("/crews/{crewId}/reviews/member")
+	@PostMapping(value = "/crews/{crewId}/reviews/member", consumes = APPLICATION_JSON_VALUE)
 	public ResponseEntity<IdResponse> createMemberReview
 	(
 		@PathVariable Long crewId,
@@ -81,7 +87,7 @@ public class ReviewController {
 	 * @param user 사용자 정보
 	 * @return status : 200 body : 조회된 리뷰 데이터
 	 */
-	@GetMapping("/reviews/{reviewId}")
+	@GetMapping(value = "/reviews/{reviewId}", produces = APPLICATION_JSON_VALUE)
 	public ResponseEntity<ApiResponse<ReviewResponse>> getSingleReview
 	(
 		@PathVariable Long reviewId,
@@ -89,5 +95,41 @@ public class ReviewController {
 	) {
 		ReviewResponse findReview = reviewService.getSingleReview(reviewId, user.id());
 		return ResponseEntity.ok().body(new ApiResponse<>(findReview));
+	}
+
+	/**
+	 * <pre>
+	 *     자신에게 작성된 리뷰 전체 조회
+	 * </pre>
+	 * @param user 사용자 정보
+	 * @param pageable 페이징 데이터
+	 * @return status : 200 body : 자신에게 작성된 리뷰 전체 데이터
+	 */
+	@GetMapping(value = "/reviews/me", produces = APPLICATION_JSON_VALUE)
+	public ResponseEntity<ApiResponse<Page<ReviewResponse>>> getAllReceivedReview
+		(
+			@AuthenticationPrincipal JwtAuthentication user,
+			@PageableDefault(sort = "updatedAt", direction = Sort.Direction.DESC) Pageable pageable
+		) {
+		Page<ReviewResponse> reviews = reviewService.getAllReceivedReview(user.id(), pageable);
+		return ResponseEntity.ok().body(new ApiResponse<>(reviews));
+	}
+
+	/**
+	 * <pre>
+	 *     자신이 작성한 리뷰 전체 조회
+	 * </pre>
+	 * @param user 사용자 정보
+	 * @param pageable 페이징 데이터
+	 * @return status : 200 body : 자신이 작성한 리뷰 전체 데이터
+	 */
+	@GetMapping(value = "/reviews", produces = APPLICATION_JSON_VALUE)
+	public ResponseEntity<ApiResponse<Page<ReviewResponse>>> getAllWroteReview
+	(
+		@AuthenticationPrincipal JwtAuthentication user,
+		@PageableDefault(sort = "updatedAt", direction = Sort.Direction.DESC) Pageable pageable
+	) {
+		Page<ReviewResponse> reviews = reviewService.getAllWroteReview(user.id(), pageable);
+		return ResponseEntity.ok().body(new ApiResponse<>(reviews));
 	}
 }

--- a/src/main/java/com/prgrms/mukvengers/domain/review/exception/LeaderNotFoundException.java
+++ b/src/main/java/com/prgrms/mukvengers/domain/review/exception/LeaderNotFoundException.java
@@ -1,0 +1,14 @@
+package com.prgrms.mukvengers.domain.review.exception;
+
+import com.prgrms.mukvengers.global.exception.ErrorCode;
+import com.prgrms.mukvengers.global.exception.ServiceException;
+
+public class LeaderNotFoundException extends ServiceException {
+
+	private static final ErrorCode ERROR_CODE = ErrorCode.LEADER_NOT_FOUND;
+	private static final String MESSAGE_KEY = "exception.review.leader.notfound";
+
+	public LeaderNotFoundException(Long userId) {
+		super(ERROR_CODE, MESSAGE_KEY, new Object[] {userId});
+	}
+}

--- a/src/main/java/com/prgrms/mukvengers/domain/review/exception/MemberNotFoundException.java
+++ b/src/main/java/com/prgrms/mukvengers/domain/review/exception/MemberNotFoundException.java
@@ -1,0 +1,14 @@
+package com.prgrms.mukvengers.domain.review.exception;
+
+import com.prgrms.mukvengers.global.exception.ErrorCode;
+import com.prgrms.mukvengers.global.exception.ServiceException;
+
+public class MemberNotFoundException extends ServiceException {
+
+	private static final ErrorCode ERROR_CODE = ErrorCode.MEMBER_NOT_FOUND;
+	private static final String MESSAGE_KEY = "exception.review.member.notfound";
+
+	public MemberNotFoundException(Long userId) {
+		super(ERROR_CODE, MESSAGE_KEY, new Object[] {userId});
+	}
+}

--- a/src/main/java/com/prgrms/mukvengers/domain/review/exception/ReviewNotAccessException.java
+++ b/src/main/java/com/prgrms/mukvengers/domain/review/exception/ReviewNotAccessException.java
@@ -1,0 +1,14 @@
+package com.prgrms.mukvengers.domain.review.exception;
+
+import com.prgrms.mukvengers.global.exception.ErrorCode;
+import com.prgrms.mukvengers.global.exception.ServiceException;
+
+public class ReviewNotAccessException extends ServiceException {
+
+	private static final ErrorCode ERROR_CODE = ErrorCode.REVIEW_NO_ACCESS;
+	private static final String MESSAGE_KEY = "exception.review.no.access";
+
+	public ReviewNotAccessException(Long userId) {
+		super(ERROR_CODE, MESSAGE_KEY, new Object[] {userId});
+	}
+}

--- a/src/main/java/com/prgrms/mukvengers/domain/review/exception/ReviewNotFoundException.java
+++ b/src/main/java/com/prgrms/mukvengers/domain/review/exception/ReviewNotFoundException.java
@@ -1,0 +1,14 @@
+package com.prgrms.mukvengers.domain.review.exception;
+
+import com.prgrms.mukvengers.global.exception.ErrorCode;
+import com.prgrms.mukvengers.global.exception.ServiceException;
+
+public class ReviewNotFoundException extends ServiceException {
+
+	private static final ErrorCode ERROR_CODE = ErrorCode.REVIEW_NOT_FOUND;
+	private static final String MESSAGE_KEY = "exception.review.notfound";
+
+	public ReviewNotFoundException(Long reviewId) {
+		super(ERROR_CODE, MESSAGE_KEY, new Object[] {reviewId});
+	}
+}

--- a/src/main/java/com/prgrms/mukvengers/domain/review/mapper/ReviewMapper.java
+++ b/src/main/java/com/prgrms/mukvengers/domain/review/mapper/ReviewMapper.java
@@ -1,9 +1,8 @@
 package com.prgrms.mukvengers.domain.review.mapper;
 
-import static org.mapstruct.ReportingPolicy.*;
-
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
+import org.mapstruct.Named;
 
 import com.prgrms.mukvengers.domain.crew.model.Crew;
 import com.prgrms.mukvengers.domain.review.dto.request.CreateLeaderReviewRequest;
@@ -12,7 +11,7 @@ import com.prgrms.mukvengers.domain.review.dto.response.ReviewResponse;
 import com.prgrms.mukvengers.domain.review.model.Review;
 import com.prgrms.mukvengers.domain.user.model.User;
 
-@Mapper(componentModel = "spring", unmappedTargetPolicy = IGNORE)
+@Mapper(componentModel = "spring")
 public interface ReviewMapper {
 
 	@Mapping(source = "reviewer", target = "reviewer")
@@ -30,6 +29,7 @@ public interface ReviewMapper {
 	@Mapping(source = "crew.promiseTime", target = "promiseTime")
 	@Mapping(source = "request.content", target = "content")
 	@Mapping(source = "request.mannerPoint", target = "mannerPoint")
+	@Mapping(source = "request", target = "tastePoint", qualifiedByName = "tasteScoreToZero")
 	Review toReview(CreateMemberReviewRequest request, User reviewer, User reviewee, Crew crew);
 
 	@Mapping(source = "reviewer", target = "reviewer")
@@ -40,4 +40,9 @@ public interface ReviewMapper {
 	@Mapping(source = "mannerPoint", target = "mannerPoint")
 	@Mapping(source = "tastePoint", target = "tastePoint")
 	ReviewResponse toReviewResponse(Review review);
+
+	@Named("tasteScoreToZero")
+	default Integer tasteScoreNullToZero(CreateMemberReviewRequest request) {
+		return 0;
+	}
 }

--- a/src/main/java/com/prgrms/mukvengers/domain/review/model/Review.java
+++ b/src/main/java/com/prgrms/mukvengers/domain/review/model/Review.java
@@ -13,6 +13,7 @@ import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 
+import org.hibernate.annotations.DynamicInsert;
 import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.Where;
 
@@ -29,6 +30,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = PROTECTED)
 @Where(clause = "deleted = false")
 @SQLDelete(sql = "UPDATE review SET deleted = true where id=?")
+@DynamicInsert
 public class Review extends BaseEntity {
 
 	@Id
@@ -69,7 +71,7 @@ public class Review extends BaseEntity {
 		this.promiseTime = validatePromiseTime(promiseTime);
 		this.content = content;
 		this.mannerPoint = validateMannerPoint(mannerPoint);
-		this.tastePoint = tastePoint;
+		this.tastePoint =  validateTastePoint(tastePoint);
 	}
 
 	private LocalDateTime validatePromiseTime(LocalDateTime promiseTime) {
@@ -90,5 +92,10 @@ public class Review extends BaseEntity {
 	private Integer validateMannerPoint(Integer mannerPoint) {
 		notNull(mannerPoint, "유효하지 않는 매너점수입니다.");
 		return mannerPoint;
+	}
+
+	private Integer validateTastePoint(Integer tastePoint) {
+		notNull(tastePoint, "유효하지 않는 맛 점수입니다.");
+		return tastePoint;
 	}
 }

--- a/src/main/java/com/prgrms/mukvengers/domain/review/repository/ReviewRepository.java
+++ b/src/main/java/com/prgrms/mukvengers/domain/review/repository/ReviewRepository.java
@@ -1,8 +1,26 @@
 package com.prgrms.mukvengers.domain.review.repository;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import com.prgrms.mukvengers.domain.review.model.Review;
 
 public interface ReviewRepository extends JpaRepository<Review, Long> {
+
+	@Query(value = """
+		SELECT r
+		FROM Review r
+		WHERE r.reviewee.id = :userId
+		""")
+	Page<Review> findByReviewee(@Param(value = "userId") Long userId, Pageable pageable);
+
+	@Query(value = """
+		SELECT r
+		FROM Review r
+		WHERE r.reviewer.id = :userId
+		""")
+	Page<Review> findByReviewer(@Param(value = "userId") Long userId, Pageable pageable);
 }

--- a/src/main/java/com/prgrms/mukvengers/domain/review/service/ReviewService.java
+++ b/src/main/java/com/prgrms/mukvengers/domain/review/service/ReviewService.java
@@ -1,5 +1,8 @@
 package com.prgrms.mukvengers.domain.review.service;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
 import com.prgrms.mukvengers.domain.review.dto.request.CreateLeaderReviewRequest;
 import com.prgrms.mukvengers.domain.review.dto.request.CreateMemberReviewRequest;
 import com.prgrms.mukvengers.domain.review.dto.response.ReviewResponse;
@@ -11,4 +14,9 @@ public interface ReviewService {
 	IdResponse createMemberReview(CreateMemberReviewRequest request, Long reviewerId, Long crewId);
 
 	ReviewResponse getSingleReview(Long reviewId, Long userId);
+
+	Page<ReviewResponse> getAllReceivedReview(Long userId, Pageable pageable);
+
+	Page<ReviewResponse> getAllWroteReview(Long userId, Pageable pageable);
+
 }

--- a/src/main/java/com/prgrms/mukvengers/domain/review/service/ReviewServiceImpl.java
+++ b/src/main/java/com/prgrms/mukvengers/domain/review/service/ReviewServiceImpl.java
@@ -1,5 +1,7 @@
 package com.prgrms.mukvengers.domain.review.service;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -11,6 +13,10 @@ import com.prgrms.mukvengers.domain.crewmember.repository.CrewMemberRepository;
 import com.prgrms.mukvengers.domain.review.dto.request.CreateLeaderReviewRequest;
 import com.prgrms.mukvengers.domain.review.dto.request.CreateMemberReviewRequest;
 import com.prgrms.mukvengers.domain.review.dto.response.ReviewResponse;
+import com.prgrms.mukvengers.domain.review.exception.LeaderNotFoundException;
+import com.prgrms.mukvengers.domain.review.exception.MemberNotFoundException;
+import com.prgrms.mukvengers.domain.review.exception.ReviewNotAccessException;
+import com.prgrms.mukvengers.domain.review.exception.ReviewNotFoundException;
 import com.prgrms.mukvengers.domain.review.mapper.ReviewMapper;
 import com.prgrms.mukvengers.domain.review.model.Review;
 import com.prgrms.mukvengers.domain.review.repository.ReviewRepository;
@@ -48,15 +54,19 @@ public class ReviewServiceImpl implements ReviewService {
 
 		crewMemberRepository.findCrewMemberByCrewIdAndUserId(crewId, reviewee.getId())
 			.filter(crewMember -> crewMember.getRole() == Role.LEADER)
-			.orElseThrow(() -> new IllegalArgumentException("해당 밥모임원의 리더가 아닙니다."));
+			.orElseThrow(() -> new LeaderNotFoundException(reviewee.getId()));
 
 		crewMemberRepository.findCrewMemberByCrewIdAndUserId(crewId, reviewer.getId())
 			.filter(crewMember -> crewMember.getRole() == Role.MEMBER)
-			.orElseThrow(() -> new IllegalArgumentException("해당 밥모임원의 참여자가 아닙니다."));
+			.orElseThrow(() -> new MemberNotFoundException(reviewer.getId()));
 
 		Review review = reviewMapper.toReview(leaderReviewRequest, reviewer, reviewee, crew);
 
 		Review saveReview = reviewRepository.save(review);
+
+		reviewee.addMannerScore(saveReview.getMannerPoint());
+		reviewee.addTasteScore(saveReview.getTastePoint());
+
 		return new IdResponse(saveReview.getId());
 	}
 
@@ -75,15 +85,18 @@ public class ReviewServiceImpl implements ReviewService {
 
 		crewMemberRepository.findCrewMemberByCrewIdAndUserId(crewId, reviewee.getId())
 			.filter(crewMember -> crewMember.getRole() == Role.MEMBER)
-			.orElseThrow(() -> new IllegalArgumentException("해당 밥모임원의 참여자가 아닙니다."));
+			.orElseThrow(() -> new MemberNotFoundException(reviewee.getId()));
 
 		crewMemberRepository.findCrewMemberByCrewIdAndUserId(crewId, reviewer.getId())
 			.filter(crewMember -> crewMember.getRole() == Role.MEMBER)
-			.orElseThrow(() -> new IllegalArgumentException("해당 밥모임원의 참여자가 아닙니다."));
+			.orElseThrow(() -> new MemberNotFoundException(reviewee.getId()));
 
 		Review review = reviewMapper.toReview(memberReviewRequest, reviewer, reviewee, crew);
 
 		Review saveReview = reviewRepository.save(review);
+
+		reviewee.addMannerScore(saveReview.getMannerPoint());
+
 		return new IdResponse(saveReview.getId());
 	}
 
@@ -91,12 +104,26 @@ public class ReviewServiceImpl implements ReviewService {
 	public ReviewResponse getSingleReview(Long reviewId, Long userId) {
 
 		Review review = reviewRepository.findById(reviewId)
-			.orElseThrow(() -> new IllegalArgumentException("해당 리뷰는 존재하지 않는 리뷰입니다."));
+			.orElseThrow(() -> new ReviewNotFoundException(reviewId));
 
 		if (!review.getReviewer().isSameUser(userId) && !review.getReviewee().isSameUser(userId)) {
-			throw new IllegalArgumentException("해당 리뷰를 볼 수 있는 접근 권한이 없습니다.");
+			throw new ReviewNotAccessException(userId);
 		}
 
 		return reviewMapper.toReviewResponse(review);
+	}
+
+	@Override
+	public Page<ReviewResponse> getAllReceivedReview(Long userId, Pageable pageable) {
+
+		return reviewRepository.findByReviewee(userId, pageable)
+			.map(reviewMapper::toReviewResponse);
+	}
+
+	@Override
+	public Page<ReviewResponse> getAllWroteReview(Long userId, Pageable pageable) {
+
+		return reviewRepository.findByReviewer(userId, pageable)
+			.map(reviewMapper::toReviewResponse);
 	}
 }

--- a/src/main/java/com/prgrms/mukvengers/domain/user/model/User.java
+++ b/src/main/java/com/prgrms/mukvengers/domain/user/model/User.java
@@ -114,4 +114,11 @@ public class User extends BaseEntity {
 		return Objects.equals(this.id, userId);
 	}
 
+	public void addMannerScore(Integer mannerScore) {
+		this.mannerScore = (0.1 * mannerScore);
+	}
+
+	public void addTasteScore(Integer tasteScore) {
+		this.tasteScore += tasteScore;
+	}
 }

--- a/src/main/java/com/prgrms/mukvengers/global/exception/ErrorCode.java
+++ b/src/main/java/com/prgrms/mukvengers/global/exception/ErrorCode.java
@@ -28,6 +28,12 @@ public enum ErrorCode {
 	// Crew
 	CREW_NOT_FOUND(HttpStatus.NOT_FOUND, "CR001", "존재하지 않는 모임입니다."),
 
+	// Review
+	REVIEW_NOT_FOUND(HttpStatus.NOT_FOUND, "R001", "존재하지 않는 리뷰입니다."),
+	LEADER_NOT_FOUND(HttpStatus.NOT_FOUND, "R002", "해당 밥모임에 존재하지 않는 리더입니다."),
+	MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "R003", "해당 밥모임에 존재하지 않는 밥모임원입니다."),
+	REVIEW_NO_ACCESS(HttpStatus.UNAUTHORIZED, "R004", "해당 리뷰를 볼 수 있는 접근 권한이 없습니다."),
+
 	// Auth
 	INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "A001", "유효하지 않은 토큰입니다."),
 	EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, "A002", "만료된 토큰입니다."),

--- a/src/test/java/com/prgrms/mukvengers/domain/crew/repository/CrewRepositoryTest.java
+++ b/src/test/java/com/prgrms/mukvengers/domain/crew/repository/CrewRepositoryTest.java
@@ -1,11 +1,9 @@
 package com.prgrms.mukvengers.domain.crew.repository;
 
-import static com.prgrms.mukvengers.utils.UserObjectProvider.*;
 import static org.assertj.core.api.Assertions.*;
 
 import java.util.List;
 
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.locationtech.jts.geom.Coordinate;
@@ -17,19 +15,8 @@ import org.springframework.data.domain.Slice;
 
 import com.prgrms.mukvengers.base.RepositoryTest;
 import com.prgrms.mukvengers.domain.crew.model.Crew;
-import com.prgrms.mukvengers.domain.user.model.User;
 
 class CrewRepositoryTest extends RepositoryTest {
-
-	User reviewer;
-
-	User reviewee;
-
-	@BeforeEach
-	void setCrews() {
-		reviewer = savedUser;
-		reviewee = userRepository.save(createUser());
-	}
 
 	@Test
 	@DisplayName("[성공] 맵 api 아이디로 해당 가게의 밥 모임을 조회한다.")

--- a/src/test/java/com/prgrms/mukvengers/domain/review/repository/ReviewRepositoryTest.java
+++ b/src/test/java/com/prgrms/mukvengers/domain/review/repository/ReviewRepositoryTest.java
@@ -1,0 +1,76 @@
+package com.prgrms.mukvengers.domain.review.repository;
+
+import static com.prgrms.mukvengers.domain.crew.model.vo.Status.*;
+import static org.assertj.core.api.AssertionsForClassTypes.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
+import com.prgrms.mukvengers.base.RepositoryTest;
+import com.prgrms.mukvengers.domain.crew.model.Crew;
+import com.prgrms.mukvengers.domain.review.model.Review;
+import com.prgrms.mukvengers.domain.user.model.User;
+import com.prgrms.mukvengers.utils.CrewObjectProvider;
+import com.prgrms.mukvengers.utils.ReviewObjectProvider;
+import com.prgrms.mukvengers.utils.UserObjectProvider;
+
+class ReviewRepositoryTest extends RepositoryTest {
+
+
+	@Test
+	@DisplayName("[성공] 리뷰이 아이디가 사용자 아이디와 같으면 나에 대한 리뷰를 조회할 수 있다.")
+	void findByReviewee_success() {
+
+		// given
+		User createUser = UserObjectProvider.createUser("kakao_1234");
+		User reviewer = userRepository.save(createUser);
+
+		Crew createCrew = CrewObjectProvider.createCrew(savedStore, RECRUITING);
+		Crew crew = crewRepository.save(createCrew);
+
+		Integer page = 0;
+
+		Integer size = 5;
+
+		Pageable pageable = PageRequest.of(page, size);
+
+		Review review = ReviewObjectProvider.createLeaderReview(reviewer, savedUser, crew);
+		reviewRepository.save(review);
+
+		// when
+		Page<Review> findReview = reviewRepository.findByReviewee(savedUserId, pageable);
+
+		// then
+		assertThat(findReview.getContent().get(0).getReviewee().getId()).isEqualTo(savedUserId);
+	}
+
+	@Test
+	@DisplayName("[성공] 리뷰어 아이디가 사용자 아이디와 같으면 내가 작성한 리뷰를 조회할 수 있다.")
+	void findByReviewer_success() {
+
+		// given
+		User createUser = UserObjectProvider.createUser("kakao_1234");
+		User reviewee = userRepository.save(createUser);
+
+		Crew createCrew = CrewObjectProvider.createCrew(savedStore, RECRUITING);
+		Crew crew = crewRepository.save(createCrew);
+
+		Integer page = 0;
+
+		Integer size = 5;
+
+		Pageable pageable = PageRequest.of(page, size);
+
+		Review review = ReviewObjectProvider.createLeaderReview(savedUser, reviewee, crew);
+		reviewRepository.save(review);
+
+		// when
+		Page<Review> findReview = reviewRepository.findByReviewer(savedUserId, pageable);
+
+		// then
+		assertThat(findReview.getContent().get(0).getReviewer().getId()).isEqualTo(savedUserId);
+	}
+}

--- a/src/test/java/com/prgrms/mukvengers/utils/ReviewObjectProvider.java
+++ b/src/test/java/com/prgrms/mukvengers/utils/ReviewObjectProvider.java
@@ -1,6 +1,9 @@
 package com.prgrms.mukvengers.utils;
 
 import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 import com.prgrms.mukvengers.domain.crew.model.Crew;
 import com.prgrms.mukvengers.domain.review.dto.request.CreateLeaderReviewRequest;
@@ -12,7 +15,7 @@ public class ReviewObjectProvider {
 
 	public static final LocalDateTime PROMISE_TIME = LocalDateTime.now();
 	public static final String CONTENT = "추가로 작성하고 싶은 내용을 입력해주세요.";
-	public static final Integer MANNER_POINT = 10;
+	public static final Integer MANNER_POINT = 5;
 	public static final Integer TASTE_POINT = 5;
 
 	public static Review createLeaderReview(User reviewer, User reviewee, Crew crew) {
@@ -35,7 +38,14 @@ public class ReviewObjectProvider {
 			.promiseTime(PROMISE_TIME)
 			.content(CONTENT)
 			.mannerPoint(MANNER_POINT)
+			.tastePoint(0)
 			.build();
+	}
+
+	public static List<Review> createReviews(User reviewer, User reviewee, Crew crew) {
+
+		return IntStream.range(0, 20)
+			.mapToObj(i -> createMemberReview(reviewer, reviewee, crew)).collect(Collectors.toList());
 	}
 
 	public static CreateLeaderReviewRequest createLeaderReviewRequest(Long revieweeId) {

--- a/src/test/resources/schema.sql
+++ b/src/test/resources/schema.sql
@@ -88,7 +88,7 @@ CREATE TABLE review
     promise_time dateTime     NOT NULL,
     content      varchar(255) NULL,
     manner_point int          NOT NULL,
-    taste_point  int          NULL,
+    taste_point  int          NOT NULL DEFAULT 0,
     created_at   dateTime     NOT NULL DEFAULT now(),
     updated_at   dateTime     NOT NULL DEFAULT now(),
     deleted      boolean      NOT NULL DEFAULT false,


### PR DESCRIPTION
### 🌱 작업 사항 
- 내가 작성한 리뷰 API 생성
- 나에 대한 리뷰 API 생성
- 리뷰 생성 시 User에 매너 온도 & 맛잘알 점수 등록

### ❓ 리뷰 포인트
- [x] #96 
- [x] Review와 DB에서는 매너 점수, 맛잘알 점수 컬럼명이 mannerPoint, tastePoint이지만, 
User에서는 mannerScore, tasteScore로 섞여 사용되고 있습니다. 이부분은 ERD 수정이 필요하여 다음 PR에 적용하도록 하겠습니다!
- [ ] 현재 ReviewResponse로 반환하는 데이터가 너무 커서 ReviewControllerTest에 작성하는 코드가 깁니다.
이부분도 다음 PR에 적용하도록 하겠습니다!
- [ ] 현재 ReviewController에서 Page를 그대로 리턴하고 있습니다. 이 부분도 Custom해야된다고 느끼는데 어떤 값들이 필요한지 프론트분들과 협의가 필요할 것 같아 협의 후 적용하도록 하겠습니다!

### 🦄 관련 이슈
resolves #89 


