### PR TITLE
CORS 설정에 OPTIONS 메서드 추가

### DIFF
--- a/src/main/java/com/prgrms/mukvengers/global/config/web/WebConfig.java
+++ b/src/main/java/com/prgrms/mukvengers/global/config/web/WebConfig.java
@@ -13,8 +13,8 @@ public class WebConfig implements WebMvcConfigurer {
 	@Override
 	public void addCorsMappings(CorsRegistry registry) {
 		registry.addMapping("/**")
-			.allowedOriginPatterns("/**")
-			.allowedMethods("GET", "POST", "PUT", "PATCH", "DELETE")
+			.allowedOrigins("*")
+			.allowedMethods("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS")
 			.allowCredentials(true);
 	}
 

--- a/src/main/java/com/prgrms/mukvengers/global/config/web/WebConfig.java
+++ b/src/main/java/com/prgrms/mukvengers/global/config/web/WebConfig.java
@@ -13,7 +13,7 @@ public class WebConfig implements WebMvcConfigurer {
 	@Override
 	public void addCorsMappings(CorsRegistry registry) {
 		registry.addMapping("/**")
-			.allowedOrigins("*")
+			.allowedOriginPatterns("/**")
 			.allowedMethods("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS")
 			.allowCredentials(true);
 	}


### PR DESCRIPTION
### 🌱 작업 사항 
- 외부자원 요청시, 사전 요청으로 OPTION 메서드를 사용해서 보내기 때문에 허용 메서드에 추가 해야할 필요가 있었음
- 프론트의 요청으로 긴급 해결사항(HOTFIX)
- 적용 중 에러 발생 해결 (참고: https://kim6394.tistory.com/273)