### PR TITLE
[#105] 모임 생성시 가게 정보가 없을 경우 가게를 저장한다.

### DIFF
--- a/src/main/java/com/prgrms/mukvengers/domain/crew/dto/request/CreateCrewRequest.java
+++ b/src/main/java/com/prgrms/mukvengers/domain/crew/dto/request/CreateCrewRequest.java
@@ -7,11 +7,12 @@ import javax.validation.constraints.Min;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
 
+import com.prgrms.mukvengers.domain.store.dto.request.CreateStoreRequest;
+
 public record CreateCrewRequest(
-	@NotBlank String placeId,
+
+	@NotNull CreateStoreRequest createStoreRequest,
 	@NotBlank String name,
-	@NotBlank String longitude,
-	@NotBlank String latitude,
 	@NotNull LocalDateTime promiseTime,
 	@Min(value = 2) @Max(value = 8) Integer capacity,
 	@NotBlank String content,

--- a/src/main/java/com/prgrms/mukvengers/domain/crew/mapper/CrewMapper.java
+++ b/src/main/java/com/prgrms/mukvengers/domain/crew/mapper/CrewMapper.java
@@ -18,6 +18,7 @@ public interface CrewMapper {
 	@Mapping(target = "category", source = "createCrewRequest.category", qualifiedByName = "categoryMethod")
 	@Mapping(target = "promiseTime", source = "createCrewRequest.promiseTime")
 	@Mapping(target = "store", source = "store")
+	@Mapping(target = "location", source = "store.location")
 	Crew toCrew(CreateCrewRequest createCrewRequest, Store store);
 
 	@Mapping(target = "promiseTime", source = "crew.promiseTime")

--- a/src/main/java/com/prgrms/mukvengers/domain/crew/service/CrewServiceImpl.java
+++ b/src/main/java/com/prgrms/mukvengers/domain/crew/service/CrewServiceImpl.java
@@ -42,7 +42,6 @@ public class CrewServiceImpl implements CrewService {
 	private final StoreRepository storeRepository;
 	private final CrewMemberRepository crewMemberRepository;
 	private final CrewMapper crewMapper;
-
 	private final StoreMapper storeMapper;
 
 	@Override

--- a/src/main/java/com/prgrms/mukvengers/domain/crew/service/CrewServiceImpl.java
+++ b/src/main/java/com/prgrms/mukvengers/domain/crew/service/CrewServiceImpl.java
@@ -22,7 +22,7 @@ import com.prgrms.mukvengers.domain.crew.mapper.CrewMapper;
 import com.prgrms.mukvengers.domain.crew.model.Crew;
 import com.prgrms.mukvengers.domain.crew.repository.CrewRepository;
 import com.prgrms.mukvengers.domain.crewmember.repository.CrewMemberRepository;
-import com.prgrms.mukvengers.domain.store.exception.StoreNotFoundException;
+import com.prgrms.mukvengers.domain.store.mapper.StoreMapper;
 import com.prgrms.mukvengers.domain.store.model.Store;
 import com.prgrms.mukvengers.domain.store.repository.StoreRepository;
 import com.prgrms.mukvengers.domain.user.exception.UserNotFoundException;
@@ -43,6 +43,8 @@ public class CrewServiceImpl implements CrewService {
 	private final CrewMemberRepository crewMemberRepository;
 	private final CrewMapper crewMapper;
 
+	private final StoreMapper storeMapper;
+
 	@Override
 	@Transactional
 	public IdResponse create(CreateCrewRequest createCrewRequest, Long userId) {
@@ -50,8 +52,8 @@ public class CrewServiceImpl implements CrewService {
 		userRepository.findById(userId)
 			.orElseThrow(() -> new UserNotFoundException(userId));
 
-		Store store = storeRepository.findByPlaceId(createCrewRequest.placeId())
-			.orElseThrow(() -> new StoreNotFoundException(createCrewRequest.placeId()));
+		Store store = storeRepository.findByPlaceId(createCrewRequest.createStoreRequest().placeId())
+			.orElse(storeRepository.save(storeMapper.toStore(createCrewRequest.createStoreRequest())));
 
 		Crew crew = crewMapper.toCrew(createCrewRequest, store);
 

--- a/src/test/java/com/prgrms/mukvengers/domain/crew/api/CrewControllerTest.java
+++ b/src/test/java/com/prgrms/mukvengers/domain/crew/api/CrewControllerTest.java
@@ -65,9 +65,15 @@ class CrewControllerTest extends ControllerTest {
 						.description("모임을 생성합니다. 생성한 유저는 모임원이 되고 방장 역할을 가집니다.")
 						.requestSchema(CREATE_CREW_REQUEST)
 						.requestFields(
-							fieldWithPath("latitude").type(STRING).description("위도"),
-							fieldWithPath("longitude").type(STRING).description("경도"),
-							fieldWithPath("placeId").type(STRING).description("지도 api 제공 id"),
+							fieldWithPath("createStoreRequest.latitude").type(NUMBER).description("위도"),
+							fieldWithPath("createStoreRequest.longitude").type(NUMBER).description("경도"),
+							fieldWithPath("createStoreRequest.placeId").type(STRING).description("지도 api 제공 id"),
+							fieldWithPath("createStoreRequest.placeName").type(STRING).description("가게 이름"),
+							fieldWithPath("createStoreRequest.categories").type(STRING).description("가게 카테고리"),
+							fieldWithPath("createStoreRequest.roadAddressName").type(STRING).description("가게 도로명 주소"),
+							fieldWithPath("createStoreRequest.photoUrls").type(STRING).description("가게 사진 URL"),
+							fieldWithPath("createStoreRequest.kakaoPlaceUrl").type(STRING).description("가게 상세 페이지 URL"),
+							fieldWithPath("createStoreRequest.phoneNumber").type(STRING).description("가게 전화번호"),
 							fieldWithPath("name").type(STRING).description("밥 모임 이름"),
 							fieldWithPath("capacity").type(NUMBER).description("밥 모임 정원"),
 							fieldWithPath("promiseTime").type(STRING).description("약속 시간"),

--- a/src/test/java/com/prgrms/mukvengers/domain/crew/facade/CrewFacadeServiceTest.java
+++ b/src/test/java/com/prgrms/mukvengers/domain/crew/facade/CrewFacadeServiceTest.java
@@ -31,8 +31,8 @@ class CrewFacadeServiceTest extends ServiceTest {
 		CreateCrewRequest createCrewRequest = getCreateCrewRequest(savedStore.getPlaceId());
 		IdResponse idResponse = crewFacadeService.create(createCrewRequest, savedUserId);
 
-		double parseLatitude = Double.parseDouble(createCrewRequest.latitude());
-		double parseLongitude = Double.parseDouble(createCrewRequest.longitude());
+		double parseLatitude = createCrewRequest.createStoreRequest().latitude();
+		double parseLongitude = createCrewRequest.createStoreRequest().longitude();
 		Point location = gf.createPoint(new Coordinate(parseLongitude, parseLatitude));
 
 		Optional<Crew> optionalCrew = crewRepository.findById(idResponse.id());

--- a/src/test/java/com/prgrms/mukvengers/domain/crew/service/CrewServiceImplTest.java
+++ b/src/test/java/com/prgrms/mukvengers/domain/crew/service/CrewServiceImplTest.java
@@ -40,8 +40,8 @@ class CrewServiceImplTest extends ServiceTest {
 		//given
 		CreateCrewRequest createCrewRequest = CrewObjectProvider.getCreateCrewRequest(savedStore.getPlaceId());
 
-		double parseLatitude = Double.parseDouble(createCrewRequest.latitude());
-		double parseLongitude = Double.parseDouble(createCrewRequest.longitude());
+		double parseLatitude = createCrewRequest.createStoreRequest().latitude();
+		double parseLongitude = createCrewRequest.createStoreRequest().longitude();
 		Point location = gf.createPoint(new Coordinate(parseLongitude, parseLatitude));
 		IdResponse idResponse = crewService.create(createCrewRequest, savedUser.getId());
 

--- a/src/test/java/com/prgrms/mukvengers/utils/CrewObjectProvider.java
+++ b/src/test/java/com/prgrms/mukvengers/utils/CrewObjectProvider.java
@@ -2,6 +2,7 @@ package com.prgrms.mukvengers.utils;
 
 import static com.prgrms.mukvengers.domain.crew.model.vo.Category.*;
 import static com.prgrms.mukvengers.domain.crew.model.vo.CrewStatus.*;
+import static com.prgrms.mukvengers.utils.StoreObjectProvider.*;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -51,12 +52,10 @@ public class CrewObjectProvider {
 			.collect(Collectors.toList());
 	}
 
-	public static CreateCrewRequest getCreateCrewRequest(String mapStoreId) {
+	public static CreateCrewRequest getCreateCrewRequest(String placeId) {
 		return new CreateCrewRequest(
-			mapStoreId,
+			getCreateStoreRequest(placeId),
 			NAME,
-			LONGITUDE,
-			LATITUDE,
 			PROMISE_TIME,
 			CAPACITY,
 			CONTENT,


### PR DESCRIPTION
### 🌱 작업 사항 
- 모임 생성시 가게 정보를 같이 받아 가게 데이터가 없으면 가게 정보를 DB에 저장합니다.
- 모임 생성 DTO 수정
- 모임 생성 로직 수정
### ❓ 리뷰 포인트

### 🦄 관련 이슈
- resolves #105 



