### PR TITLE
[#24] cp: target 'deploy/application.jar' is not a directory 문제 해결

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,6 +29,10 @@ ext {
     set('snippetsDir', file("build/generated-snippets"))
 }
 
+jar {
+    enabled = false
+}
+
 swaggerSources {
     sample {
         setInputFile(file("${project.buildDir}/api-spec/openapi3.yaml"))
@@ -133,3 +137,8 @@ task copyDocument(type: Copy) {
 tasks.withType(BootJar).configureEach {
     dependsOn 'copySwaggerUI'
 }
+
+
+
+
+


### PR DESCRIPTION
- 빌드 스크립트에 jar 작업시에 plain 파일 생성 제외 동작 추가
  - build.gradle에서 jar 작업시에 plain 파일 생성 제외
- 참고 자료
  - https://earth-95.tistory.com/132
  - https://wonyong-jang.github.io/devops/2022/07/17/DevOps-gradle.html



