### PR TITLE
[#113] 가게 이미지 Url DB 저장 데이터 타입 수정

### DIFF
--- a/src/main/resources/db/migration/V3.0__alter_store_table.sql
+++ b/src/main/resources/db/migration/V3.0__alter_store_table.sql
@@ -1,0 +1,3 @@
+## 가게 이미지 URL 컬럼 데이터 타입 변경 varchar(255) -> TEXT
+ALTER TABLE store
+    MODIFY photo_urls TEXT;

--- a/src/test/resources/schema.sql
+++ b/src/test/resources/schema.sql
@@ -39,7 +39,7 @@ CREATE TABLE store
     place_name        varchar(255) NULL,
     categories        varchar(255) NULL,
     road_address_name varchar(255) NULL,
-    photo_urls        varchar(255) NULL,
+    photo_urls        TEXT NULL,
     kakao_place_url   varchar(255) NULL,
     phone_number      varchar(255) NULL,
     created_at        dateTime     NOT NULL DEFAULT now(),


### PR DESCRIPTION
### 🌱 작업 사항 
가게의 photo_urls DB 컬럼 데이터 타입 varchar(255) -> TEXT로 수정
### ❓ 리뷰 포인트
- 추후에 카테고리, 사진 URL은 테이블을 따로 만들어야 겠습니다.
### 🦄 관련 이슈
- resolves #113 



