### PR TITLE
[#98] 사용자가 참여를 위해 작성한 신청서 조회 

### DIFF
--- a/src/main/java/com/prgrms/mukvengers/domain/proposal/api/ProposalController.java
+++ b/src/main/java/com/prgrms/mukvengers/domain/proposal/api/ProposalController.java
@@ -39,4 +39,21 @@ public class ProposalController {
 		return ResponseEntity.ok().body(new ApiResponse<>(responses));
 	}
 
+	/**
+	 * <pre>
+	 *     사용자가 방장인 아니고 참여자인 모임의 신청서를 모두 조회합니다.
+	 * </pre>
+	 * @param user 사용자 정보
+	 * @return status : 200, body : 조회된 모든 신청서 데이터
+	 */
+	@GetMapping(value = "/proposals/member", produces = APPLICATION_JSON_VALUE)
+	public ResponseEntity<ApiResponse<ProposalResponses>> getProposalsByMemberId
+	(
+		@AuthenticationPrincipal JwtAuthentication user
+	) {
+		ProposalResponses responses = proposalService.getProposalsByMemberId(user.id());
+
+		return ResponseEntity.ok().body(new ApiResponse<>(responses));
+	}
+
 }

--- a/src/main/java/com/prgrms/mukvengers/domain/proposal/repository/ProposalRepository.java
+++ b/src/main/java/com/prgrms/mukvengers/domain/proposal/repository/ProposalRepository.java
@@ -11,4 +11,6 @@ public interface ProposalRepository extends JpaRepository<Proposal, Long> {
 
 	List<Proposal> findAllByLeaderId(@Param("userId") Long userId);
 
+	List<Proposal> findAllByUserId(@Param("userId") Long userId);
+
 }

--- a/src/main/java/com/prgrms/mukvengers/domain/proposal/repository/ProposalRepository.java
+++ b/src/main/java/com/prgrms/mukvengers/domain/proposal/repository/ProposalRepository.java
@@ -9,8 +9,8 @@ import com.prgrms.mukvengers.domain.proposal.model.Proposal;
 
 public interface ProposalRepository extends JpaRepository<Proposal, Long> {
 
-	List<Proposal> findAllByLeaderId(@Param("userId") Long userId);
+	List<Proposal> findAllByLeaderIdOrderByCreatedAtDesc(@Param("userId") Long userId);
 
-	List<Proposal> findAllByUserId(@Param("userId") Long userId);
+	List<Proposal> findAllByUserIdOrderByCreatedAtDesc(@Param("userId") Long userId);
 
 }

--- a/src/main/java/com/prgrms/mukvengers/domain/proposal/service/ProposalService.java
+++ b/src/main/java/com/prgrms/mukvengers/domain/proposal/service/ProposalService.java
@@ -4,4 +4,6 @@ import com.prgrms.mukvengers.domain.proposal.dto.response.ProposalResponses;
 
 public interface ProposalService {
 	ProposalResponses getProposalsByLeaderId(Long userId);
+
+	ProposalResponses getProposalsByMemberId(Long userId);
 }

--- a/src/main/java/com/prgrms/mukvengers/domain/proposal/service/ProposalServiceImpl.java
+++ b/src/main/java/com/prgrms/mukvengers/domain/proposal/service/ProposalServiceImpl.java
@@ -32,4 +32,15 @@ public class ProposalServiceImpl implements ProposalService {
 		return new ProposalResponses(proposals);
 	}
 
+	@Override
+	public ProposalResponses getProposalsByMemberId(Long userId) {
+
+		List<ProposalResponse> proposals = proposalRepository.findAllByUserId(userId)
+			.stream()
+			.map(proposalMapper::toProposalResponse)
+			.collect(Collectors.toList());
+
+		return new ProposalResponses(proposals);
+	}
+
 }

--- a/src/main/java/com/prgrms/mukvengers/domain/proposal/service/ProposalServiceImpl.java
+++ b/src/main/java/com/prgrms/mukvengers/domain/proposal/service/ProposalServiceImpl.java
@@ -24,7 +24,7 @@ public class ProposalServiceImpl implements ProposalService {
 	@Override
 	public ProposalResponses getProposalsByLeaderId(Long userId) {
 
-		List<ProposalResponse> proposals = proposalRepository.findAllByLeaderId(userId)
+		List<ProposalResponse> proposals = proposalRepository.findAllByLeaderIdOrderByCreatedAtDesc(userId)
 			.stream()
 			.map(proposalMapper::toProposalResponse)
 			.collect(Collectors.toList());
@@ -35,7 +35,7 @@ public class ProposalServiceImpl implements ProposalService {
 	@Override
 	public ProposalResponses getProposalsByMemberId(Long userId) {
 
-		List<ProposalResponse> proposals = proposalRepository.findAllByUserId(userId)
+		List<ProposalResponse> proposals = proposalRepository.findAllByUserIdOrderByCreatedAtDesc(userId)
 			.stream()
 			.map(proposalMapper::toProposalResponse)
 			.collect(Collectors.toList());

--- a/src/test/java/com/prgrms/mukvengers/domain/proposal/api/ProposalControllerTest.java
+++ b/src/test/java/com/prgrms/mukvengers/domain/proposal/api/ProposalControllerTest.java
@@ -78,4 +78,52 @@ class ProposalControllerTest extends ControllerTest {
 			));
 
 	}
+
+	@Test
+	@DisplayName("[성공] 사용자가 방장인 아니고 참여자인 모임의 신청서를 모두 조회합니다.")
+	void getProposalsByMemberId_success() throws Exception {
+
+		User user = createUser("1232456789");
+		userRepository.save(user);
+
+		Crew crew = createCrew(savedStore, CrewStatus.RECRUITING);
+		crewRepository.save(crew);
+
+		List<Proposal> proposals = createProposals(savedUser, user.getId(), crew.getId());
+		proposalRepository.saveAll(proposals);
+
+		mockMvc.perform(get("/api/v1/proposals/member")
+				.header(AUTHORIZATION, BEARER_TYPE + accessToken)
+				.accept(APPLICATION_JSON))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.data").exists())
+			.andDo(print())
+			.andDo(document("proposal-getProposalsByLeaderId",
+				resource(
+					builder()
+						.tag(PROPOSAL)
+						.summary("사용자가 방장인 모임의 모든 신청서 조회")
+						.description("사용자가 방장인 모임에서 모임 신청을 위해 작서된 신청서를 모두 조회를 위한 API 입니다.")
+						.responseSchema(GET_PROPOSALS_BY_LEADER_ID_PROPOSAL_RESPONSE)
+						.responseFields(
+							fieldWithPath("data.responses.[].user.id").type(NUMBER).description("유저 ID"),
+							fieldWithPath("data.responses.[].user.nickname").type(STRING).description("닉네임"),
+							fieldWithPath("data.responses.[].user.profileImgUrl").type(STRING).description("프로필 이미지"),
+							fieldWithPath("data.responses.[].user.introduction").type(STRING).description("한줄 소개"),
+							fieldWithPath("data.responses.[].user.leaderCount").type(NUMBER).description("방장 횟수"),
+							fieldWithPath("data.responses.[].user.crewCount").type(NUMBER).description("모임 참여 횟수"),
+							fieldWithPath("data.responses.[].user.tasteScore").type(NUMBER).description("맛잘알 점수"),
+							fieldWithPath("data.responses.[].user.mannerScore").type(NUMBER).description("매너 온도"),
+							fieldWithPath("data.responses.[].user.mannerScore").type(NUMBER).description("매너 온도"),
+							fieldWithPath("data.responses.[].id").type(NUMBER).description("신청서 아이디"),
+							fieldWithPath("data.responses.[].content").type(STRING).description("신청서 내용"),
+							fieldWithPath("data.responses.[].status").type(STRING).description("신청서 상태"),
+							fieldWithPath("data.responses.[].leaderId").type(NUMBER).description("모임의 방장 아이디"),
+							fieldWithPath("data.responses.[].crewId").type(NUMBER).description("모임 아이디")
+						)
+						.build()
+				)
+			));
+
+	}
 }

--- a/src/test/java/com/prgrms/mukvengers/domain/proposal/service/ProposalServiceImplTest.java
+++ b/src/test/java/com/prgrms/mukvengers/domain/proposal/service/ProposalServiceImplTest.java
@@ -40,4 +40,25 @@ class ProposalServiceImplTest extends ServiceTest {
 		assertThat(responses.responses()).hasSize(proposals.size());
 	}
 
+	@Test
+	@DisplayName("[성공] 사용자가 방장인 아니고 참여자인 모임의 신청서를 모두 조회합니다.")
+	void getProposalsByMemberId_success() {
+
+		//given
+		User user = createUser("1232456789");
+		userRepository.save(user);
+
+		Crew crew = createCrew(savedStore, CrewStatus.RECRUITING);
+		crewRepository.save(crew);
+
+		List<Proposal> proposals = createProposals(savedUser, user.getId(), crew.getId());
+		proposalRepository.saveAll(proposals);
+
+		//when
+		ProposalResponses responses = proposalService.getProposalsByMemberId(savedUser.getId());
+
+		//then
+		assertThat(responses.responses()).hasSize(proposals.size());
+	}
+
 }


### PR DESCRIPTION
### 🌱 작업 사항 
- 사용자의 아이디로 신청서 테이블의 작성자 컬럼과 일치하는 모든 신청서 데이터를 조회합니다.
### ❓ 리뷰 포인트

### 🦄 관련 이슈
- resolves #98 


