### PR TITLE
[#116] Review 필드명 수정 및 Review Controller 테스트 컨벤션 리팩토링

### DIFF
--- a/src/main/java/com/prgrms/mukvengers/domain/review/dto/request/CreateLeaderReviewRequest.java
+++ b/src/main/java/com/prgrms/mukvengers/domain/review/dto/request/CreateLeaderReviewRequest.java
@@ -2,9 +2,11 @@ package com.prgrms.mukvengers.domain.review.dto.request;
 
 import javax.validation.constraints.NotNull;
 
+import org.springframework.lang.Nullable;
+
 public record CreateLeaderReviewRequest(
 	@NotNull Long leaderId,
-	@NotNull String content,
+	@Nullable String content,
 	@NotNull Integer mannerScore,
 	@NotNull Integer tasteScore
 ) {

--- a/src/main/java/com/prgrms/mukvengers/domain/review/dto/request/CreateLeaderReviewRequest.java
+++ b/src/main/java/com/prgrms/mukvengers/domain/review/dto/request/CreateLeaderReviewRequest.java
@@ -5,7 +5,7 @@ import javax.validation.constraints.NotNull;
 public record CreateLeaderReviewRequest(
 	@NotNull Long leaderId,
 	@NotNull String content,
-	@NotNull Integer mannerPoint,
-	@NotNull Integer tastePoint
+	@NotNull Integer mannerScore,
+	@NotNull Integer tasteScore
 ) {
 }

--- a/src/main/java/com/prgrms/mukvengers/domain/review/dto/request/CreateMemberReviewRequest.java
+++ b/src/main/java/com/prgrms/mukvengers/domain/review/dto/request/CreateMemberReviewRequest.java
@@ -2,9 +2,11 @@ package com.prgrms.mukvengers.domain.review.dto.request;
 
 import javax.validation.constraints.NotNull;
 
+import org.springframework.lang.Nullable;
+
 public record CreateMemberReviewRequest(
 	@NotNull Long revieweeId,
-	@NotNull String content,
+	@Nullable String content,
 	@NotNull Integer mannerScore
 ) {
 }

--- a/src/main/java/com/prgrms/mukvengers/domain/review/dto/request/CreateMemberReviewRequest.java
+++ b/src/main/java/com/prgrms/mukvengers/domain/review/dto/request/CreateMemberReviewRequest.java
@@ -5,6 +5,6 @@ import javax.validation.constraints.NotNull;
 public record CreateMemberReviewRequest(
 	@NotNull Long revieweeId,
 	@NotNull String content,
-	@NotNull Integer mannerPoint
+	@NotNull Integer mannerScore
 ) {
 }

--- a/src/main/java/com/prgrms/mukvengers/domain/review/dto/response/ReviewResponse.java
+++ b/src/main/java/com/prgrms/mukvengers/domain/review/dto/response/ReviewResponse.java
@@ -10,7 +10,7 @@ public record ReviewResponse(UserProfileResponse reviewer,
 							 CrewResponse crew,
 							 LocalDateTime promiseTime,
 							 String content,
-							 Integer mannerPoint,
-							 Integer tastePoint
+							 Integer mannerScore,
+							 Integer tasteScore
 							 ) {
 }

--- a/src/main/java/com/prgrms/mukvengers/domain/review/mapper/ReviewMapper.java
+++ b/src/main/java/com/prgrms/mukvengers/domain/review/mapper/ReviewMapper.java
@@ -19,8 +19,8 @@ public interface ReviewMapper {
 	@Mapping(source = "crew", target = "crew")
 	@Mapping(source = "crew.promiseTime", target = "promiseTime")
 	@Mapping(source = "request.content", target = "content")
-	@Mapping(source = "request.mannerPoint", target = "mannerPoint")
-	@Mapping(source = "request.tastePoint", target = "tastePoint")
+	@Mapping(source = "request.mannerScore", target = "mannerScore")
+	@Mapping(source = "request.tasteScore", target = "tasteScore")
 	Review toReview(CreateLeaderReviewRequest request, User reviewer, User reviewee, Crew crew);
 
 	@Mapping(source = "reviewer", target = "reviewer")
@@ -28,8 +28,8 @@ public interface ReviewMapper {
 	@Mapping(source = "crew", target = "crew")
 	@Mapping(source = "crew.promiseTime", target = "promiseTime")
 	@Mapping(source = "request.content", target = "content")
-	@Mapping(source = "request.mannerPoint", target = "mannerPoint")
-	@Mapping(source = "request", target = "tastePoint", qualifiedByName = "tasteScoreToZero")
+	@Mapping(source = "request.mannerScore", target = "mannerScore")
+	@Mapping(source = "request", target = "tasteScore", qualifiedByName = "tasteScoreToZero")
 	Review toReview(CreateMemberReviewRequest request, User reviewer, User reviewee, Crew crew);
 
 	@Mapping(source = "reviewer", target = "reviewer")
@@ -37,8 +37,8 @@ public interface ReviewMapper {
 	@Mapping(source = "crew", target = "crew")
 	@Mapping(source = "promiseTime", target = "promiseTime")
 	@Mapping(source = "content", target = "content")
-	@Mapping(source = "mannerPoint", target = "mannerPoint")
-	@Mapping(source = "tastePoint", target = "tastePoint")
+	@Mapping(source = "mannerScore", target = "mannerScore")
+	@Mapping(source = "tasteScore", target = "tasteScore")
 	ReviewResponse toReviewResponse(Review review);
 
 	@Named("tasteScoreToZero")

--- a/src/main/java/com/prgrms/mukvengers/domain/review/model/Review.java
+++ b/src/main/java/com/prgrms/mukvengers/domain/review/model/Review.java
@@ -38,11 +38,11 @@ public class Review extends BaseEntity {
 	private Long id;
 
 	@ManyToOne
-	@JoinColumn(name = "reviewer", referencedColumnName = "id")
+	@JoinColumn(name = "reviewer_id", referencedColumnName = "id")
 	private User reviewer;
 
 	@ManyToOne
-	@JoinColumn(name = "reviewee", referencedColumnName = "id")
+	@JoinColumn(name = "reviewee_id", referencedColumnName = "id")
 	private User reviewee;
 
 	@ManyToOne
@@ -56,22 +56,22 @@ public class Review extends BaseEntity {
 	private String content;
 
 	@Column(nullable = false)
-	private Integer mannerPoint;
+	private Integer mannerScore;
 
 	@Column
-	private Integer tastePoint;
+	private Integer tasteScore;
 
 	@Builder
 	protected Review(User reviewer, User reviewee, Crew crew, LocalDateTime promiseTime,
-		String content, Integer mannerPoint, Integer tastePoint) {
+		String content, Integer mannerScore, Integer tasteScore) {
 
 		this.reviewer = validateUser(reviewer);
 		this.reviewee = validateUser(reviewee);
 		this.crew = validateCrew(crew);
 		this.promiseTime = validatePromiseTime(promiseTime);
 		this.content = content;
-		this.mannerPoint = validateMannerPoint(mannerPoint);
-		this.tastePoint =  validateTastePoint(tastePoint);
+		this.mannerScore = validateMannerScore(mannerScore);
+		this.tasteScore =  validateTasteScore(tasteScore);
 	}
 
 	private LocalDateTime validatePromiseTime(LocalDateTime promiseTime) {
@@ -89,13 +89,13 @@ public class Review extends BaseEntity {
 		return crew;
 	}
 
-	private Integer validateMannerPoint(Integer mannerPoint) {
-		notNull(mannerPoint, "유효하지 않는 매너점수입니다.");
-		return mannerPoint;
+	private Integer validateMannerScore(Integer mannerScore) {
+		notNull(mannerScore, "유효하지 않는 매너점수입니다.");
+		return mannerScore;
 	}
 
-	private Integer validateTastePoint(Integer tastePoint) {
-		notNull(tastePoint, "유효하지 않는 맛 점수입니다.");
-		return tastePoint;
+	private Integer validateTasteScore(Integer tasteScore) {
+		notNull(tasteScore, "유효하지 않는 맛 점수입니다.");
+		return tasteScore;
 	}
 }

--- a/src/main/java/com/prgrms/mukvengers/domain/review/service/ReviewServiceImpl.java
+++ b/src/main/java/com/prgrms/mukvengers/domain/review/service/ReviewServiceImpl.java
@@ -64,9 +64,6 @@ public class ReviewServiceImpl implements ReviewService {
 
 		Review saveReview = reviewRepository.save(review);
 
-		reviewee.addMannerScore(saveReview.getMannerPoint());
-		reviewee.addTasteScore(saveReview.getTastePoint());
-
 		return new IdResponse(saveReview.getId());
 	}
 
@@ -95,7 +92,7 @@ public class ReviewServiceImpl implements ReviewService {
 
 		Review saveReview = reviewRepository.save(review);
 
-		reviewee.addMannerScore(saveReview.getMannerPoint());
+		reviewee.addMannerScore(saveReview.getMannerScore());
 
 		return new IdResponse(saveReview.getId());
 	}

--- a/src/test/java/com/prgrms/mukvengers/base/ControllerTest.java
+++ b/src/test/java/com/prgrms/mukvengers/base/ControllerTest.java
@@ -26,6 +26,7 @@ import com.prgrms.mukvengers.config.RestDocsConfig;
 import com.prgrms.mukvengers.domain.crew.repository.CrewRepository;
 import com.prgrms.mukvengers.domain.crewmember.repository.CrewMemberRepository;
 import com.prgrms.mukvengers.domain.proposal.repository.ProposalRepository;
+import com.prgrms.mukvengers.domain.review.repository.ReviewRepository;
 import com.prgrms.mukvengers.domain.store.model.Store;
 import com.prgrms.mukvengers.domain.store.repository.StoreRepository;
 import com.prgrms.mukvengers.domain.user.model.User;
@@ -67,6 +68,9 @@ public abstract class ControllerTest {
 
 	@Autowired
 	protected CrewMemberRepository crewMemberRepository;
+
+	@Autowired
+	protected ReviewRepository reviewRepository;
 
 	@Autowired
 	protected ProposalRepository proposalRepository;

--- a/src/test/java/com/prgrms/mukvengers/domain/review/api/ReviewControllerTest.java
+++ b/src/test/java/com/prgrms/mukvengers/domain/review/api/ReviewControllerTest.java
@@ -85,8 +85,8 @@ class ReviewControllerTest extends ControllerTest {
 						.requestFields(
 							fieldWithPath("leaderId").description("방장의 아이디"),
 							fieldWithPath("content").description("추가로 작성하고 싶은 내용"),
-							fieldWithPath("mannerPoint").description("방장에 대한 매너 온도"),
-							fieldWithPath("tastePoint").description("방장에 대한 맛잘알 점수"))
+							fieldWithPath("mannerScore").description("방장에 대한 매너 온도"),
+							fieldWithPath("tasteScore").description("방장에 대한 맛잘알 점수"))
 						.responseFields()
 						.build()
 				)
@@ -124,7 +124,7 @@ class ReviewControllerTest extends ControllerTest {
 						.requestFields(
 							fieldWithPath("revieweeId").description("리뷰이 아이디"),
 							fieldWithPath("content").description("추가로 작성하고 싶은 내용"),
-							fieldWithPath("mannerPoint").description("리뷰이에 대한 매너 온도"))
+							fieldWithPath("mannerScore").description("리뷰이에 대한 매너 온도"))
 						.responseFields()
 						.build()
 				)
@@ -179,8 +179,8 @@ class ReviewControllerTest extends ControllerTest {
 
 							fieldWithPath("data.promiseTime").type(ARRAY).description("리뷰하고자 하는 밥모임 약속 시간"),
 							fieldWithPath("data.content").type(STRING).description("리뷰하고자 하는 밥모임 간단 한줄 리뷰 "),
-							fieldWithPath("data.mannerPoint").type(NUMBER).description("리뷰하고자 하는 밥모임 매너 온도"),
-							fieldWithPath("data.tastePoint").type(NUMBER).description("리뷰하고자 하는 밥모임 맛잘알 점수")
+							fieldWithPath("data.mannerScore").type(NUMBER).description("리뷰하고자 하는 밥모임 매너 온도"),
+							fieldWithPath("data.tasteScore").type(NUMBER).description("리뷰하고자 하는 밥모임 맛잘알 점수")
 						)
 						.build()
 				)
@@ -317,9 +317,9 @@ class ReviewControllerTest extends ControllerTest {
 
 							fieldWithPath("data.content.[].promiseTime").type(ARRAY).description("리뷰하고자 하는 밥 모임 약속 시간"),
 							fieldWithPath("data.content.[].content").type(STRING).description("리뷰하고자 하는 리뷰이에 대한 설명"),
-							fieldWithPath("data.content.[].mannerPoint").type(NUMBER)
+							fieldWithPath("data.content.[].mannerScore").type(NUMBER)
 								.description("리뷰하고자 하는 리뷰이에 대한 매너 점수"),
-							fieldWithPath("data.content.[].tastePoint").type(NUMBER)
+							fieldWithPath("data.content.[].tasteScore").type(NUMBER)
 								.description("리뷰하고자 하는 리뷰이에 대한 맛잘알 점수"),
 
 							fieldWithPath("data.pageable.sort.empty").type(BOOLEAN).description("빈 페이지 여부"),

--- a/src/test/java/com/prgrms/mukvengers/domain/review/api/ReviewControllerTest.java
+++ b/src/test/java/com/prgrms/mukvengers/domain/review/api/ReviewControllerTest.java
@@ -16,11 +16,11 @@ import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpHeaders;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 
+import com.epages.restdocs.apispec.Schema;
 import com.prgrms.mukvengers.base.ControllerTest;
 import com.prgrms.mukvengers.domain.crew.model.Crew;
 import com.prgrms.mukvengers.domain.crew.model.vo.CrewStatus;
@@ -29,7 +29,6 @@ import com.prgrms.mukvengers.domain.crewmember.model.vo.Role;
 import com.prgrms.mukvengers.domain.review.dto.request.CreateLeaderReviewRequest;
 import com.prgrms.mukvengers.domain.review.dto.request.CreateMemberReviewRequest;
 import com.prgrms.mukvengers.domain.review.model.Review;
-import com.prgrms.mukvengers.domain.review.repository.ReviewRepository;
 import com.prgrms.mukvengers.domain.user.model.User;
 import com.prgrms.mukvengers.utils.CrewMemberObjectProvider;
 import com.prgrms.mukvengers.utils.ReviewObjectProvider;
@@ -37,15 +36,15 @@ import com.prgrms.mukvengers.utils.UserObjectProvider;
 
 class ReviewControllerTest extends ControllerTest {
 
-	@Autowired
-	ReviewController reviewController;
+	public static final Schema CREATE_LEADER_REVIEW_REQUEST = new Schema("createReviewOfLeaderRequest");
+	public static final Schema CREATE_MEMBER_REVIEW_REQUEST = new Schema("createReviewOfMemberRequest");
+	public static final Schema SINGLE_REVIEW_DETAIL = new Schema("singleReviewDetail");
+	public static final Schema ALL_RECEIVED_REVIEW = new Schema("allReceivedReview");
+	public static final Schema ALL_WROTE_REVIEW = new Schema("allWroteReview");
 
-	@Autowired
-	ReviewRepository reviewRepository;
-
-	User reviewer;
-	User reviewee;
-	Crew crew;
+	private User reviewer;
+	private User reviewee;
+	private Crew crew;
 
 	@BeforeEach
 	void setCrew() {
@@ -81,13 +80,16 @@ class ReviewControllerTest extends ControllerTest {
 				resource(
 					builder()
 						.tag(REVIEW)
-						.summary("방장에 대한 리뷰 생성")
+						.summary("방장에 대한 리뷰 생성 API")
+						.requestSchema(CREATE_LEADER_REVIEW_REQUEST)
+						.description("방장에 대한 리뷰를 작성합니다.")
 						.requestFields(
 							fieldWithPath("leaderId").description("방장의 아이디"),
 							fieldWithPath("content").description("추가로 작성하고 싶은 내용"),
 							fieldWithPath("mannerScore").description("방장에 대한 매너 온도"),
 							fieldWithPath("tasteScore").description("방장에 대한 맛잘알 점수"))
-						.responseFields()
+						.responseHeaders(
+							headerWithName("Location").description("조회해볼 수 있는 요청 주소"))
 						.build()
 				)
 			));
@@ -120,12 +122,15 @@ class ReviewControllerTest extends ControllerTest {
 				resource(
 					builder()
 						.tag(REVIEW)
-						.summary("방장이 아닌 밥모임원에 대한 리뷰 생성")
+						.summary("밥모임원에 대한 리뷰 생성 API")
+						.requestSchema(CREATE_MEMBER_REVIEW_REQUEST)
+						.description("방장이 아닌 밥모임원에 대한 리뷰를 작성합니다.")
 						.requestFields(
 							fieldWithPath("revieweeId").description("리뷰이 아이디"),
 							fieldWithPath("content").description("추가로 작성하고 싶은 내용"),
 							fieldWithPath("mannerScore").description("리뷰이에 대한 매너 온도"))
-						.responseFields()
+						.responseHeaders(
+							headerWithName("Location").description("조회해볼 수 있는 요청 주소"))
 						.build()
 				)
 			));
@@ -148,7 +153,9 @@ class ReviewControllerTest extends ControllerTest {
 				resource(
 					builder()
 						.tag(REVIEW)
-						.summary("리뷰 단건 조회")
+						.summary("리뷰 단건 조회 API")
+						.responseSchema(SINGLE_REVIEW_DETAIL)
+						.description("하나의 리뷰를 상세 조회 합니다.")
 						.responseFields(
 							fieldWithPath("data.reviewer.id").description("리뷰어의 아이디"),
 							fieldWithPath("data.reviewer.nickname").description("리뷰어의 닉네임"),
@@ -191,7 +198,7 @@ class ReviewControllerTest extends ControllerTest {
 	@DisplayName("[성공] 리뷰이 아이디가 사용자 아이디와 같다면 본인에게 작성된 모든 리뷰를 조회할 수 있다.")
 	void getAllReceivedReview() throws Exception {
 		// given
-		List<Review> reviews = ReviewObjectProvider.createReviews(reviewer, reviewee, crew);
+		List<Review> reviews = ReviewObjectProvider.createReviews(reviewee, reviewer, crew);
 
 		reviewRepository.saveAll(reviews);
 
@@ -214,9 +221,60 @@ class ReviewControllerTest extends ControllerTest {
 				resource(
 					builder()
 						.tag(REVIEW)
-						.summary("나에게 작성된 모든 리뷰를 조회합니다.")
+						.summary("나에 대한 모든 리뷰 조회 API")
+						.responseSchema(ALL_RECEIVED_REVIEW)
+						.description("나에게 작성된 모든 리뷰를 조회합니다.")
 						.responseFields(
-							fieldWithPath("data.content.[]").type(ARRAY).description("전체 리뷰"),
+							fieldWithPath("data.content.[].reviewer.id").type(NUMBER)
+								.description("리뷰를 작성하고자 하는 사용자의 아이디"),
+							fieldWithPath("data.content.[].reviewer.nickname").type(STRING)
+								.description("리뷰를 작성하고자 하는 사용자의 닉네임"),
+							fieldWithPath("data.content.[].reviewer.profileImgUrl").type(STRING)
+								.description("리뷰를 작성하고자 하는 사용자의 프로필 URL"),
+							fieldWithPath("data.content.[].reviewer.introduction").type(STRING)
+								.description("리뷰를 작성하고자 하는 사용자의 자기 소개"),
+							fieldWithPath("data.content.[].reviewer.leaderCount").type(NUMBER)
+								.description("리뷰를 작성하고자 하는 사용자의 리더 횟수"),
+							fieldWithPath("data.content.[].reviewer.crewCount").type(NUMBER)
+								.description("리뷰를 작성하고자 하는 사용자의 밥모임 참여 횟수"),
+							fieldWithPath("data.content.[].reviewer.tasteScore").type(NUMBER)
+								.description("리뷰를 작성하고자 하는 사용자의 맛잘알 점수"),
+							fieldWithPath("data.content.[].reviewer.mannerScore").type(NUMBER)
+								.description("리뷰를 작성하고자 하는 사용자의 매너 온도 점수"),
+
+							fieldWithPath("data.content.[].reviewee.id").type(NUMBER).description("리뷰 남기고자하는 사용자의 아이디"),
+							fieldWithPath("data.content.[].reviewee.nickname").type(STRING)
+								.description("리뷰 남기고자하는 사용자의 닉네임"),
+							fieldWithPath("data.content.[].reviewee.profileImgUrl").type(STRING)
+								.description("리뷰 남기고자하는 사용자의 프로필 URL"),
+							fieldWithPath("data.content.[].reviewee.introduction").type(STRING)
+								.description("리뷰 남기고자하는 사용자의 자기 소개"),
+							fieldWithPath("data.content.[].reviewee.leaderCount").type(NUMBER)
+								.description("리뷰 남기고자하는 사용자의 리더 횟수"),
+							fieldWithPath("data.content.[].reviewee.crewCount").type(NUMBER)
+								.description("리뷰 남기고자하는 사용자의 밥모임 참여 횟수"),
+							fieldWithPath("data.content.[].reviewee.tasteScore").type(NUMBER)
+								.description("리뷰 남기고자하는 사용자의 맛잘알 점수"),
+							fieldWithPath("data.content.[].reviewee.mannerScore").type(NUMBER)
+								.description("리뷰 남기고자하는 사용자의 매너 온도 점수"),
+
+							fieldWithPath("data.content.[].crew.id").type(NUMBER).description("리뷰하고자하는 밥 모임 아이디"),
+							fieldWithPath("data.content.[].crew.name").type(STRING).description("리뷰하고자하는 밥 모임 이름"),
+							fieldWithPath("data.content.[].crew.capacity").type(NUMBER).description("리뷰하고자하는 밥 모임 정원"),
+							fieldWithPath("data.content.[].crew.promiseTime").type(ARRAY).description("리뷰하고자하는 약속 시간"),
+							fieldWithPath("data.content.[].crew.status").type(STRING).description("리뷰하고자하는 밥 모임 상태"),
+							fieldWithPath("data.content.[].crew.currentMember").description("리뷰하고자하는 밥 모임 현재 인원 수"),
+							fieldWithPath("data.content.[].crew.content").type(STRING).description("리뷰하고자하는 밥 모임 내용"),
+							fieldWithPath("data.content.[].crew.category").type(STRING)
+								.description("리뷰하고자하는 밥 모임 카테고리"),
+
+							fieldWithPath("data.content.[].promiseTime").type(ARRAY).description("리뷰하고자 하는 밥 모임 약속 시간"),
+							fieldWithPath("data.content.[].content").type(STRING).description("리뷰하고자 하는 리뷰이에 대한 설명"),
+							fieldWithPath("data.content.[].mannerScore").type(NUMBER)
+								.description("리뷰하고자 하는 리뷰이에 대한 매너 점수"),
+							fieldWithPath("data.content.[].tasteScore").type(NUMBER)
+								.description("리뷰하고자 하는 리뷰이에 대한 맛잘알 점수"),
+
 							fieldWithPath("data.pageable.sort.empty").type(BOOLEAN).description("빈 페이지 여부"),
 							fieldWithPath("data.pageable.sort.sorted").type(BOOLEAN).description("페이지 정렬 여부"),
 							fieldWithPath("data.pageable.sort.unsorted").type(BOOLEAN)
@@ -270,7 +328,9 @@ class ReviewControllerTest extends ControllerTest {
 				resource(
 					builder()
 						.tag(REVIEW)
-						.summary("내가 작성한 한든 리뷰를 조회합니다.")
+						.summary("내가 작성한 모든 리뷰 조회 API")
+						.responseSchema(ALL_WROTE_REVIEW)
+						.description("다른 밥모임원에게 작성한 모든 리뷰를 조회합니다.")
 						.responseFields(
 							fieldWithPath("data.content.[].reviewer.id").type(NUMBER)
 								.description("리뷰를 작성하고자 하는 사용자의 아이디"),

--- a/src/test/java/com/prgrms/mukvengers/domain/review/service/ReviewServiceImplTest.java
+++ b/src/test/java/com/prgrms/mukvengers/domain/review/service/ReviewServiceImplTest.java
@@ -11,7 +11,6 @@ import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -20,7 +19,6 @@ import com.prgrms.mukvengers.base.ServiceTest;
 import com.prgrms.mukvengers.domain.crew.model.Crew;
 import com.prgrms.mukvengers.domain.crewmember.model.CrewMember;
 import com.prgrms.mukvengers.domain.crewmember.model.vo.Role;
-import com.prgrms.mukvengers.domain.crewmember.repository.CrewMemberRepository;
 import com.prgrms.mukvengers.domain.review.dto.request.CreateLeaderReviewRequest;
 import com.prgrms.mukvengers.domain.review.dto.request.CreateMemberReviewRequest;
 import com.prgrms.mukvengers.domain.review.dto.response.ReviewResponse;
@@ -31,12 +29,9 @@ import com.prgrms.mukvengers.utils.CrewMemberObjectProvider;
 
 class ReviewServiceImplTest extends ServiceTest {
 
-	@Autowired
-	CrewMemberRepository crewMemberRepository;
-
-	User reviewer;
-	User reviewee;
-	Crew crew;
+	private User reviewer;
+	private User reviewee;
+	private Crew crew;
 
 	@BeforeEach
 	void setReview() {

--- a/src/test/java/com/prgrms/mukvengers/domain/review/service/ReviewServiceImplTest.java
+++ b/src/test/java/com/prgrms/mukvengers/domain/review/service/ReviewServiceImplTest.java
@@ -69,8 +69,6 @@ class ReviewServiceImplTest extends ServiceTest {
 		// then
 		assertThat(findReview).isPresent();
 		assertThat(findReview.get().getReviewee().getId()).isEqualTo(leader.getUserId());
-		assertThat(findReview.get().getMannerPoint()).isEqualTo(MANNER_POINT);
-		assertThat(findReview.get().getTastePoint()).isEqualTo(TASTE_POINT);
 	}
 
 	@Test
@@ -96,8 +94,8 @@ class ReviewServiceImplTest extends ServiceTest {
 
 		// then
 		assertThat(findReview).isPresent();
-		assertThat(findReview.get().getMannerPoint()).isEqualTo(MANNER_POINT);
-		assertThat(findReview.get().getTastePoint()).isZero();
+		assertThat(findReview.get().getMannerScore()).isEqualTo(MANNER_SCORE);
+		assertThat(findReview.get().getTasteScore()).isZero();
 	}
 
 	@Test

--- a/src/test/java/com/prgrms/mukvengers/utils/ReviewObjectProvider.java
+++ b/src/test/java/com/prgrms/mukvengers/utils/ReviewObjectProvider.java
@@ -15,8 +15,8 @@ public class ReviewObjectProvider {
 
 	public static final LocalDateTime PROMISE_TIME = LocalDateTime.now();
 	public static final String CONTENT = "추가로 작성하고 싶은 내용을 입력해주세요.";
-	public static final Integer MANNER_POINT = 5;
-	public static final Integer TASTE_POINT = 5;
+	public static final Integer MANNER_SCORE = 5;
+	public static final Integer TASTE_SCORE = 5;
 
 	public static Review createLeaderReview(User reviewer, User reviewee, Crew crew) {
 		return Review.builder()
@@ -25,8 +25,8 @@ public class ReviewObjectProvider {
 			.crew(crew)
 			.promiseTime(PROMISE_TIME)
 			.content(CONTENT)
-			.mannerPoint(MANNER_POINT)
-			.tastePoint(TASTE_POINT)
+			.mannerScore(MANNER_SCORE)
+			.tasteScore(TASTE_SCORE)
 			.build();
 	}
 
@@ -37,8 +37,8 @@ public class ReviewObjectProvider {
 			.crew(crew)
 			.promiseTime(PROMISE_TIME)
 			.content(CONTENT)
-			.mannerPoint(MANNER_POINT)
-			.tastePoint(0)
+			.mannerScore(MANNER_SCORE)
+			.tasteScore(0)
 			.build();
 	}
 
@@ -52,8 +52,8 @@ public class ReviewObjectProvider {
 		return new CreateLeaderReviewRequest(
 			revieweeId,
 			CONTENT,
-			MANNER_POINT,
-			TASTE_POINT
+			MANNER_SCORE,
+			TASTE_SCORE
 		);
 	}
 
@@ -61,7 +61,7 @@ public class ReviewObjectProvider {
 		return new CreateMemberReviewRequest(
 			revieweeId,
 			CONTENT,
-			MANNER_POINT
+			MANNER_SCORE
 		);
 	}
 }

--- a/src/test/resources/schema.sql
+++ b/src/test/resources/schema.sql
@@ -81,19 +81,19 @@ CREATE TABLE crew_member
 CREATE TABLE review
 (
     id           bigint       NOT NULL PRIMARY KEY AUTO_INCREMENT,
-    reviewer     bigint       NOT NULL,
-    reviewee     bigint       NOT NULL,
+    reviewer_id  bigint       NOT NULL,
+    reviewee_id  bigint       NOT NULL,
     crew_id      bigint       NOT NULL,
     promise_time dateTime     NOT NULL,
     content      varchar(255) NULL,
-    manner_point int          NOT NULL,
-    taste_point  int          NOT NULL DEFAULT 0,
+    manner_score int          NOT NULL,
+    taste_score  int          NOT NULL DEFAULT 0,
     created_at   dateTime     NOT NULL DEFAULT now(),
     updated_at   dateTime     NOT NULL DEFAULT now(),
     deleted      boolean      NOT NULL DEFAULT false,
 
-    FOREIGN KEY fk_review_reviewer (reviewer) REFERENCES users (id),
-    FOREIGN KEY fk_review_reviewee (reviewee) REFERENCES users (id),
+    FOREIGN KEY fk_review_reviewer (reviewer_id) REFERENCES users (id),
+    FOREIGN KEY fk_review_reviewee (reviewee_id) REFERENCES users (id),
     FOREIGN KEY fk_review_crew_id (crew_id) REFERENCES crew (id)
 );
 

--- a/src/test/resources/schema.sql
+++ b/src/test/resources/schema.sql
@@ -39,7 +39,7 @@ CREATE TABLE store
     place_name        varchar(255) NULL,
     categories        varchar(255) NULL,
     road_address_name varchar(255) NULL,
-    photo_urls        TEXT NULL,
+    photo_urls        TEXT         NULL,
     kakao_place_url   varchar(255) NULL,
     phone_number      varchar(255) NULL,
     created_at        dateTime     NOT NULL DEFAULT now(),


### PR DESCRIPTION
### 🌱 작업 사항 
- `작성자(Reviewer)`와 리뷰하고자 하는 받는이`(Reviewee)`의 아이디를 나타내는 필드명이 reviewer, reviewee 로
컬럼명을 보았을 때 **아이디 값을 가진다는 것**을 알기 어렵기 때문에 각각 `reviewer_id, reviewee_id`로 변경하였습니다.
- User 테이블에서는 mannerScore와 tasteScore 로 Reivew 테이블에서는 mannerPoint, tastePoint 로 각각 다른 컬럼명을 사용하고 있었기 때문에 `mannerScore`, `tasteScore`라는 이름으로 통일하도록 변경하였습니다.
- mannerScore, tasteScore 필드명 변경으로 인한 프로덕션 코드 및 테스트 코드 수정하였습니다.
- 리뷰 컨트롤러 tag, summary, description, schema 컨벤션 적용하도록 수정하였습니다.

### ❓ 리뷰 포인트
- 혹시 빠진 컨벤션이 있다면 말씀해주세요!

### 🦄 관련 이슈
resolves #116 



