### PR TITLE
[#120] 모임 생성시 ResponseBody에 모임 아이디를 반환

### DIFF
--- a/src/main/java/com/prgrms/mukvengers/domain/crew/api/CrewController.java
+++ b/src/main/java/com/prgrms/mukvengers/domain/crew/api/CrewController.java
@@ -60,7 +60,7 @@ public class CrewController {
 	) {
 		IdResponse idResponse = crewFacadeService.create(createCrewRequest, user.id());
 		URI location = UriComponentsBuilder.fromUriString("/api/v1/crews/" + idResponse.id()).build().toUri();
-		return ResponseEntity.created(location).build();
+		return ResponseEntity.created(location).body(idResponse);
 	}
 
 	/**

--- a/src/test/java/com/prgrms/mukvengers/domain/crew/api/CrewControllerTest.java
+++ b/src/test/java/com/prgrms/mukvengers/domain/crew/api/CrewControllerTest.java
@@ -34,6 +34,7 @@ import com.prgrms.mukvengers.utils.CrewObjectProvider;
 class CrewControllerTest extends ControllerTest {
 
 	public static final Schema CREATE_CREW_REQUEST = new Schema("createCrewRequest");
+	public static final Schema CREATE_CREW_RESPONSE = new Schema("createCrewResponse");
 	public static final Schema FIND_BY_CREW_ID_CREW_REQUEST = new Schema("findByCrewIdCrewRequest");
 	public static final Schema CREW_PAGE_RESPONSE = new Schema("crewPageResponse");
 	public static final Schema FIND_BY_USER_LOCATION_CREW_REQUEST = new Schema("findByUserLocationCrewRequest");
@@ -64,6 +65,7 @@ class CrewControllerTest extends ControllerTest {
 						.summary("모임 생성 API")
 						.description("모임을 생성합니다. 생성한 유저는 모임원이 되고 방장 역할을 가집니다.")
 						.requestSchema(CREATE_CREW_REQUEST)
+						.responseSchema(CREATE_CREW_RESPONSE)
 						.requestFields(
 							fieldWithPath("createStoreRequest.latitude").type(NUMBER).description("위도"),
 							fieldWithPath("createStoreRequest.longitude").type(NUMBER).description("경도"),
@@ -81,6 +83,9 @@ class CrewControllerTest extends ControllerTest {
 							fieldWithPath("category").type(STRING).description("밥 모임 카테고리"))
 						.responseHeaders(
 							headerWithName("Location").description("조회해볼 수 있는 요청 주소"))
+						.responseFields(
+							fieldWithPath("id").type(NUMBER).description("밥 모임 아이디")
+						)
 						.build()
 				)
 			));


### PR DESCRIPTION
### 🌱 작업 사항 
- crewId를 ResponseBody에 담아 보내도록 수정
### ❓ 리뷰 포인트
- 저희 모든 create api에서 body를 린턴이 IdResponse로 되어있지만 실제로 담아주지 않는데 저희가 놓치고 있는 거 아닌지 궁금합니다.
### 🦄 관련 이슈
resolves #120 



