### PR TITLE
[#8] Cookie에 SameSite 설정을 None으로 변경

### DIFF
--- a/src/main/java/com/prgrms/mukvengers/global/security/oauth/handler/OAuthAuthenticationSuccessHandler.java
+++ b/src/main/java/com/prgrms/mukvengers/global/security/oauth/handler/OAuthAuthenticationSuccessHandler.java
@@ -9,6 +9,7 @@ import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import org.springframework.http.ResponseCookie;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
 import org.springframework.security.oauth2.core.user.OAuth2User;
@@ -63,11 +64,14 @@ public class OAuthAuthenticationSuccessHandler
 	}
 
 	private void setRefreshTokenInCookie(HttpServletResponse response, String refreshToken) {
-		final Cookie token = new Cookie("refreshToken", refreshToken);
-		token.setPath(getDefaultTargetUrl());
-		token.setSecure(true);
-		token.setHttpOnly(true);
-		token.setMaxAge(tokenService.getRefreshTokenExpirySeconds());
-		response.addCookie(token);
+		ResponseCookie token = ResponseCookie.from("refreshToken", refreshToken)
+			.path(getDefaultTargetUrl())
+			.sameSite("None")
+			.httpOnly(true)
+			.secure(true)
+			.maxAge(tokenService.getRefreshTokenExpirySeconds())
+			.build();
+
+		response.addHeader("Set-Cookie", token.toString());
 	}
 }


### PR DESCRIPTION
### 🌱 작업 사항 
- 프론트와 `refreshToken`을 원활하게 주고 받기 위해 `Cookie`설정에서 `SameSite` 값을 **`None`** 으로 변경하였습니다.
- `Cookie` 클래스보다 다양한 설정을 할 수 있는 **`ResponseCookie`** 클래스를 사용했습니다.
- [fix(Web): 쿠키에 sameSite 설정을 none으로 바꾸기](https://github.com/prgrms-web-devcourse/Team-Kkini-Mukvengers-BE/commit/13b229c99f5955b8b79296e87f9d1201e75b1c24)
- `참고 자료`: https://kindloveit.tistory.com/100
### 🦄 관련 이슈
- #38 

