### PR TITLE
[#123] 사용자 거리기반 모임 조회 응답 값 수정 

### DIFF
--- a/src/main/java/com/prgrms/mukvengers/domain/crew/api/CrewController.java
+++ b/src/main/java/com/prgrms/mukvengers/domain/crew/api/CrewController.java
@@ -25,6 +25,7 @@ import com.prgrms.mukvengers.domain.crew.dto.request.CreateCrewRequest;
 import com.prgrms.mukvengers.domain.crew.dto.request.SearchCrewRequest;
 import com.prgrms.mukvengers.domain.crew.dto.request.UpdateStatusRequest;
 import com.prgrms.mukvengers.domain.crew.dto.response.CrewDetailResponse;
+import com.prgrms.mukvengers.domain.crew.dto.response.CrewLocationResponses;
 import com.prgrms.mukvengers.domain.crew.dto.response.CrewPageResponse;
 import com.prgrms.mukvengers.domain.crew.dto.response.CrewResponses;
 import com.prgrms.mukvengers.domain.crew.facade.CrewFacadeService;
@@ -121,11 +122,11 @@ public class CrewController {
 	 * @return status : 200, body : 사용자 위치를 기반으로 특정 거리 안에 있는 밥 모임 데이터
 	 */
 	@GetMapping(produces = APPLICATION_JSON_VALUE)
-	public ResponseEntity<ApiResponse<CrewResponses>> getByLocation
+	public ResponseEntity<ApiResponse<CrewLocationResponses>> getByLocation
 	(
 		@ModelAttribute @Valid SearchCrewRequest distanceRequest
 	) {
-		CrewResponses responses = crewService.getByLocation(distanceRequest);
+		CrewLocationResponses responses = crewService.getByLocation(distanceRequest);
 		return ResponseEntity.ok().body(new ApiResponse<>(responses));
 	}
 

--- a/src/main/java/com/prgrms/mukvengers/domain/crew/dto/response/CrewLocationResponse.java
+++ b/src/main/java/com/prgrms/mukvengers/domain/crew/dto/response/CrewLocationResponse.java
@@ -1,0 +1,8 @@
+package com.prgrms.mukvengers.domain.crew.dto.response;
+
+public record CrewLocationResponse(
+	Double longitude,
+	Double latitude,
+	Long storeId
+) {
+}

--- a/src/main/java/com/prgrms/mukvengers/domain/crew/dto/response/CrewLocationResponses.java
+++ b/src/main/java/com/prgrms/mukvengers/domain/crew/dto/response/CrewLocationResponses.java
@@ -1,0 +1,8 @@
+package com.prgrms.mukvengers.domain.crew.dto.response;
+
+import java.util.List;
+
+public record CrewLocationResponses(
+	List<CrewLocationResponse> responses
+) {
+}

--- a/src/main/java/com/prgrms/mukvengers/domain/crew/mapper/CrewMapper.java
+++ b/src/main/java/com/prgrms/mukvengers/domain/crew/mapper/CrewMapper.java
@@ -4,11 +4,14 @@ import static org.mapstruct.ReportingPolicy.*;
 
 import java.util.List;
 
+import org.locationtech.jts.geom.Point;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
+import org.mapstruct.Named;
 
 import com.prgrms.mukvengers.domain.crew.dto.request.CreateCrewRequest;
 import com.prgrms.mukvengers.domain.crew.dto.response.CrewDetailResponse;
+import com.prgrms.mukvengers.domain.crew.dto.response.CrewLocationResponse;
 import com.prgrms.mukvengers.domain.crew.dto.response.CrewResponse;
 import com.prgrms.mukvengers.domain.crew.model.Crew;
 import com.prgrms.mukvengers.domain.crewmember.dto.response.CrewMemberResponse;
@@ -30,6 +33,19 @@ public interface CrewMapper {
 	CrewDetailResponse toCrewAndCrewMemberResponse(Crew crew, Integer currentMember,
 		List<CrewMemberResponse> members);
 
+	@Mapping(target = "latitude", source = "location", qualifiedByName = "latitudeMethod")
+	@Mapping(target = "longitude", source = "location", qualifiedByName = "longitudeMethod")
+	CrewLocationResponse toCrewLocationResponse(Point location, Long storeId);
+
+	@Named("latitudeMethod")
+	default Double mapLatitude(Point location) {
+		return location.getX();
+	}
+
+	@Named("longitudeMethod")
+	default Double mapLongitude(Point location) {
+		return location.getY();
+	}
 }
 
 

--- a/src/main/java/com/prgrms/mukvengers/domain/crew/service/CrewService.java
+++ b/src/main/java/com/prgrms/mukvengers/domain/crew/service/CrewService.java
@@ -6,6 +6,7 @@ import com.prgrms.mukvengers.domain.crew.dto.request.CreateCrewRequest;
 import com.prgrms.mukvengers.domain.crew.dto.request.SearchCrewRequest;
 import com.prgrms.mukvengers.domain.crew.dto.request.UpdateStatusRequest;
 import com.prgrms.mukvengers.domain.crew.dto.response.CrewDetailResponse;
+import com.prgrms.mukvengers.domain.crew.dto.response.CrewLocationResponses;
 import com.prgrms.mukvengers.domain.crew.dto.response.CrewPageResponse;
 import com.prgrms.mukvengers.domain.crew.dto.response.CrewResponses;
 import com.prgrms.mukvengers.global.common.dto.IdResponse;
@@ -20,7 +21,7 @@ public interface CrewService {
 
 	CrewPageResponse getByPlaceId(String mapStoreId, Pageable pageable);
 
-	CrewResponses getByLocation(SearchCrewRequest distanceRequest);
+	CrewLocationResponses getByLocation(SearchCrewRequest distanceRequest);
 
 	void updateStatus(UpdateStatusRequest updateStatusRequest);
 

--- a/src/main/java/com/prgrms/mukvengers/domain/crew/service/CrewServiceImpl.java
+++ b/src/main/java/com/prgrms/mukvengers/domain/crew/service/CrewServiceImpl.java
@@ -1,6 +1,7 @@
 package com.prgrms.mukvengers.domain.crew.service;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.GeometryFactory;
@@ -14,6 +15,8 @@ import com.prgrms.mukvengers.domain.crew.dto.request.CreateCrewRequest;
 import com.prgrms.mukvengers.domain.crew.dto.request.SearchCrewRequest;
 import com.prgrms.mukvengers.domain.crew.dto.request.UpdateStatusRequest;
 import com.prgrms.mukvengers.domain.crew.dto.response.CrewDetailResponse;
+import com.prgrms.mukvengers.domain.crew.dto.response.CrewLocationResponse;
+import com.prgrms.mukvengers.domain.crew.dto.response.CrewLocationResponses;
 import com.prgrms.mukvengers.domain.crew.dto.response.CrewPageResponse;
 import com.prgrms.mukvengers.domain.crew.dto.response.CrewResponses;
 import com.prgrms.mukvengers.domain.crew.exception.CrewNotFoundException;
@@ -124,28 +127,18 @@ public class CrewServiceImpl implements CrewService {
 	}
 
 	@Override
-	public CrewResponses getByLocation(SearchCrewRequest distanceRequest) {
+	public CrewLocationResponses getByLocation(SearchCrewRequest distanceRequest) {
 
 		GeometryFactory gf = new GeometryFactory();
 
 		Point location = gf.createPoint(new Coordinate(distanceRequest.longitude(), distanceRequest.latitude()));
 
-		List<CrewDetailResponse> responses = crewRepository.findAllByLocation(location,
-				distanceRequest.distance())
+		List<CrewLocationResponse> responses = crewRepository.findAllByLocation(location, distanceRequest.distance())
 			.stream()
-			.map(crew -> crewMapper.toCrewAndCrewMemberResponse(crew,
-				crewMemberRepository.countCrewMemberByCrewId(crew.getId()),
-				crewMemberRepository.findAllByCrewId(
-						crew.getId())
-					.stream()
-					.map(CrewMember -> crewMemberMapper.toCrewMemberResponse(
-						userRepository.findById(CrewMember.getUserId())
-							.orElseThrow(() -> new UserNotFoundException(CrewMember.getUserId())),
-						CrewMember.getCrewMemberRole()))
-					.toList()))
-			.toList();
+			.map(crew -> crewMapper.toCrewLocationResponse(crew.getLocation(), crew.getStore().getId()))
+			.collect(Collectors.toList());
 
-		return new CrewResponses(responses);
+		return new CrewLocationResponses(responses);
 	}
 
 	@Override

--- a/src/test/java/com/prgrms/mukvengers/domain/crew/api/CrewControllerTest.java
+++ b/src/test/java/com/prgrms/mukvengers/domain/crew/api/CrewControllerTest.java
@@ -311,26 +311,14 @@ class CrewControllerTest extends ControllerTest {
 						.description("사용자 위치로 특정 거리 안에 있는 모임을 조회합니다.")
 						.requestSchema(FIND_BY_USER_LOCATION_CREW_REQUEST)
 						.requestParameters(
-							parameterWithName("latitude").description("사용자의 위도"),
 							parameterWithName("longitude").description("사용자의 경도"),
+							parameterWithName("latitude").description("사용자의 위도"),
 							parameterWithName("distance").description("모임을 찾을 범위 거리"))
 						.responseSchema(CREW_RESPONSE)
 						.responseFields(
-							fieldWithPath("data.responses.[].currentMember").type(NUMBER).description("밥 모임 현재 인원"),
-							fieldWithPath("data.responses.[].id").type(NUMBER).description("밥 모임 아이디"),
-							fieldWithPath("data.responses.[].name").type(STRING).description("밥 모임 이름"),
-							fieldWithPath("data.responses.[].capacity").type(NUMBER).description("밥 모임 정원"),
-							fieldWithPath("data.responses.[].promiseTime").type(ARRAY).description("약속 시간"),
-							fieldWithPath("data.responses.[].status").type(STRING).description("밥 모임 상태"),
-							fieldWithPath("data.responses.[].content").type(STRING).description("밥 모임 내용"),
-							fieldWithPath("data.responses.[].category").type(STRING).description("밥 모임 카테고리"),
-							fieldWithPath("data.responses.[].members.[].userId").type(NUMBER).description("유저 ID"),
-							fieldWithPath("data.responses.[].members.[].nickname").type(STRING).description("닉네임"),
-							fieldWithPath("data.responses.[].members.[].profileImgUrl").type(STRING)
-								.description("프로필 이미지"),
-							fieldWithPath("data.responses.[].members.[].crewMemberRole").type(STRING)
-								.description("사용자의 권한"))
-
+							fieldWithPath("data.responses.[].longitude").type(NUMBER).description("가게 경도"),
+							fieldWithPath("data.responses.[].latitude").type(NUMBER).description("가게 위도"),
+							fieldWithPath("data.responses.[].storeId").type(NUMBER).description("가게 아이디"))
 						.build()
 				)
 			));

--- a/src/test/java/com/prgrms/mukvengers/domain/crew/service/CrewServiceImplTest.java
+++ b/src/test/java/com/prgrms/mukvengers/domain/crew/service/CrewServiceImplTest.java
@@ -21,6 +21,8 @@ import com.prgrms.mukvengers.domain.crew.dto.request.CreateCrewRequest;
 import com.prgrms.mukvengers.domain.crew.dto.request.SearchCrewRequest;
 import com.prgrms.mukvengers.domain.crew.dto.request.UpdateStatusRequest;
 import com.prgrms.mukvengers.domain.crew.dto.response.CrewDetailResponse;
+import com.prgrms.mukvengers.domain.crew.dto.response.CrewLocationResponse;
+import com.prgrms.mukvengers.domain.crew.dto.response.CrewLocationResponses;
 import com.prgrms.mukvengers.domain.crew.dto.response.CrewPageResponse;
 import com.prgrms.mukvengers.domain.crew.dto.response.CrewResponses;
 import com.prgrms.mukvengers.domain.crew.model.Crew;
@@ -137,10 +139,10 @@ class CrewServiceImplTest extends ServiceTest {
 		SearchCrewRequest distanceRequest = new SearchCrewRequest(longitude, latitude, distance);
 
 		//when
-		CrewResponses crewResponses = crewService.getByLocation(distanceRequest);
+		CrewLocationResponses crewLocationResponse = crewService.getByLocation(distanceRequest);
 
 		//then
-		List<CrewDetailResponse> responses = crewResponses.responses();
+		List<CrewLocationResponse> responses = crewLocationResponse.responses();
 		assertThat(responses).hasSize(1);
 
 	}


### PR DESCRIPTION
### 🌱 작업 사항 
- 사용자의 위경도를 받아 모임을 조회하는 응답 객체가 위도, 경도, 가게아이디를 반환하도록 수정하였습니다.
### ❓ 리뷰 포인트
- 사용자의 거리 기반 모임 조회 api 에서 모임의 정보와 모임원의 정보가 필요하지 않아 수정합니다.
- 응답에 위도, 경도에 대한 값이 없어 추가하였습니다.
- 가게를 조회 할 수 있도록 가게 아이디를 전달 값에 추가하였습니다.
### 🦄 관련 이슈
- resolves #123 



