### PR TITLE
[#126]  신청서(proposal) 작성 API 생성

### DIFF
--- a/src/main/java/com/prgrms/mukvengers/domain/proposal/api/ProposalController.java
+++ b/src/main/java/com/prgrms/mukvengers/domain/proposal/api/ProposalController.java
@@ -2,15 +2,25 @@ package com.prgrms.mukvengers.domain.proposal.api;
 
 import static org.springframework.http.MediaType.*;
 
+import java.net.URI;
+
+import javax.validation.Valid;
+
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.util.UriComponentsBuilder;
 
+import com.prgrms.mukvengers.domain.proposal.dto.request.CreateProposalRequest;
 import com.prgrms.mukvengers.domain.proposal.dto.response.ProposalResponses;
 import com.prgrms.mukvengers.domain.proposal.service.ProposalService;
 import com.prgrms.mukvengers.global.common.dto.ApiResponse;
+import com.prgrms.mukvengers.global.common.dto.IdResponse;
 import com.prgrms.mukvengers.global.security.jwt.JwtAuthentication;
 
 import lombok.RequiredArgsConstructor;
@@ -21,6 +31,27 @@ import lombok.RequiredArgsConstructor;
 public class ProposalController {
 
 	private final ProposalService proposalService;
+
+	/**
+	 * <pre>
+	 *     사용자가 신청서를 작성합니다.
+	 * </pre>
+	 * @param crewId 신청하고자 하는 밥모임 아이디
+	 * @param proposalRequest 신청서 생성 DTO
+	 * @param user 유저 정보
+	 * @return status : 201, body : 생성된 신청서 조회 redirectUrl
+	 */
+	@PostMapping(value = "/crews/{crewId}/proposals", consumes = APPLICATION_JSON_VALUE)
+	public ResponseEntity<IdResponse> create
+	(
+		@PathVariable Long crewId,
+		@RequestBody @Valid CreateProposalRequest proposalRequest,
+		@AuthenticationPrincipal JwtAuthentication user
+	) {
+		IdResponse proposal = proposalService.create(proposalRequest, user.id(), crewId);
+		URI location = UriComponentsBuilder.fromUriString("/api/v1/proposals/" + proposal.id()).build().toUri();
+		return ResponseEntity.created(location).body(proposal);
+	}
 
 	/**
 	 * <pre>

--- a/src/main/java/com/prgrms/mukvengers/domain/proposal/dto/request/CreateProposalRequest.java
+++ b/src/main/java/com/prgrms/mukvengers/domain/proposal/dto/request/CreateProposalRequest.java
@@ -1,0 +1,8 @@
+package com.prgrms.mukvengers.domain.proposal.dto.request;
+
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+
+public record CreateProposalRequest(@NotNull Long leaderId,
+									@NotBlank String content) {
+}

--- a/src/main/java/com/prgrms/mukvengers/domain/proposal/mapper/ProposalMapper.java
+++ b/src/main/java/com/prgrms/mukvengers/domain/proposal/mapper/ProposalMapper.java
@@ -2,11 +2,15 @@ package com.prgrms.mukvengers.domain.proposal.mapper;
 
 import org.mapstruct.Mapper;
 
+import com.prgrms.mukvengers.domain.proposal.dto.request.CreateProposalRequest;
 import com.prgrms.mukvengers.domain.proposal.dto.response.ProposalResponse;
 import com.prgrms.mukvengers.domain.proposal.model.Proposal;
+import com.prgrms.mukvengers.domain.user.model.User;
 
 @Mapper(componentModel = "spring")
 public interface ProposalMapper {
+
+	Proposal toProposal(CreateProposalRequest proposalRequest, User user, Long crewId);
 
 	ProposalResponse toProposalResponse(Proposal proposal);
 }

--- a/src/main/java/com/prgrms/mukvengers/domain/proposal/service/ProposalService.java
+++ b/src/main/java/com/prgrms/mukvengers/domain/proposal/service/ProposalService.java
@@ -1,8 +1,13 @@
 package com.prgrms.mukvengers.domain.proposal.service;
 
+import com.prgrms.mukvengers.domain.proposal.dto.request.CreateProposalRequest;
 import com.prgrms.mukvengers.domain.proposal.dto.response.ProposalResponses;
+import com.prgrms.mukvengers.global.common.dto.IdResponse;
 
 public interface ProposalService {
+
+	IdResponse create(CreateProposalRequest proposalRequest, Long userId, Long crewId);
+
 	ProposalResponses getProposalsByLeaderId(Long userId);
 
 	ProposalResponses getProposalsByMemberId(Long userId);

--- a/src/main/java/com/prgrms/mukvengers/domain/proposal/service/ProposalServiceImpl.java
+++ b/src/main/java/com/prgrms/mukvengers/domain/proposal/service/ProposalServiceImpl.java
@@ -1,15 +1,28 @@
 package com.prgrms.mukvengers.domain.proposal.service;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.prgrms.mukvengers.domain.crew.exception.CrewNotFoundException;
+import com.prgrms.mukvengers.domain.crew.model.Crew;
+import com.prgrms.mukvengers.domain.crew.model.vo.CrewStatus;
+import com.prgrms.mukvengers.domain.crew.repository.CrewRepository;
+import com.prgrms.mukvengers.domain.crewmember.model.CrewMember;
+import com.prgrms.mukvengers.domain.crewmember.repository.CrewMemberRepository;
+import com.prgrms.mukvengers.domain.proposal.dto.request.CreateProposalRequest;
 import com.prgrms.mukvengers.domain.proposal.dto.response.ProposalResponse;
 import com.prgrms.mukvengers.domain.proposal.dto.response.ProposalResponses;
 import com.prgrms.mukvengers.domain.proposal.mapper.ProposalMapper;
+import com.prgrms.mukvengers.domain.proposal.model.Proposal;
 import com.prgrms.mukvengers.domain.proposal.repository.ProposalRepository;
+import com.prgrms.mukvengers.domain.user.exception.UserNotFoundException;
+import com.prgrms.mukvengers.domain.user.model.User;
+import com.prgrms.mukvengers.domain.user.repository.UserRepository;
+import com.prgrms.mukvengers.global.common.dto.IdResponse;
 
 import lombok.RequiredArgsConstructor;
 
@@ -18,8 +31,49 @@ import lombok.RequiredArgsConstructor;
 @Transactional(readOnly = true)
 public class ProposalServiceImpl implements ProposalService {
 
+	public static final String CREW_MEMBER_COUNT_OVER_CAPACITY_EXCEPTION_MESSAGE = "밥모임의 모집 인원이 마감되어 신청서를 작성할 수 없습니다.";
+	public static final String DISMISSED_USER_EXCEPTION_MESSAGE = "강퇴된 밥모임에는 신청서를 작성할 수 없습니다.";
+	public static final String LEADER_USER_EXCEPTION_MESSAGE = "해당 밥모임의 리더는 신청서를 작성할 수 없습니다.";
+	public static final String DUPLICATE_USER_EXCEPTION_MESSAGE = "이미 신청한 밥모임에 다시 신청서를 작성할 수 없습니다.";
+
+	private final UserRepository userRepository;
+	private final CrewRepository crewRepository;
+	private final CrewMemberRepository crewMemberRepository;
 	private final ProposalRepository proposalRepository;
 	private final ProposalMapper proposalMapper;
+
+	@Override
+	public IdResponse create(CreateProposalRequest proposalRequest, Long userId, Long crewId) {
+
+		User user = userRepository.findById(userId)
+			.orElseThrow(() -> new UserNotFoundException(userId));
+
+		Crew crew = crewRepository.findById(crewId)
+			.filter(c -> c.getStatus().equals(CrewStatus.RECRUITING))
+			.orElseThrow(() -> new CrewNotFoundException(crewId));
+
+		Integer currentCrewMemberCount = crewMemberRepository.countCrewMemberByCrewId(crewId);
+
+		if (currentCrewMemberCount >= crew.getCapacity()) {
+			throw new IllegalStateException(CREW_MEMBER_COUNT_OVER_CAPACITY_EXCEPTION_MESSAGE);
+		}
+
+		Optional<CrewMember> crewMember = crewMemberRepository.findCrewMemberByCrewIdAndUserId(crewId, userId);
+
+		if (crewMember.isPresent()) {
+			switch (crewMember.get().getCrewMemberRole()) {
+				case BLOCKED -> throw new IllegalStateException(DISMISSED_USER_EXCEPTION_MESSAGE);
+				case LEADER -> throw new IllegalStateException(LEADER_USER_EXCEPTION_MESSAGE);
+				case MEMBER -> throw new IllegalStateException(DUPLICATE_USER_EXCEPTION_MESSAGE);
+			}
+		}
+
+		Proposal proposal = proposalMapper.toProposal(proposalRequest, user, crewId);
+
+		Proposal saveProposal = proposalRepository.save(proposal);
+
+		return new IdResponse(saveProposal.getId());
+	}
 
 	@Override
 	public ProposalResponses getProposalsByLeaderId(Long userId) {

--- a/src/main/java/com/prgrms/mukvengers/global/exception/ErrorCode.java
+++ b/src/main/java/com/prgrms/mukvengers/global/exception/ErrorCode.java
@@ -36,6 +36,10 @@ public enum ErrorCode {
 	REVIEW_NOT_FOUND(HttpStatus.NOT_FOUND, "R001", "존재하지 않는 리뷰입니다."),
 	REVIEW_NO_ACCESS(HttpStatus.UNAUTHORIZED, "R002", "해당 리뷰를 볼 수 있는 접근 권한이 없습니다."),
 
+
+	// Proposal
+	PROPOSAL_BLOCKED_USER(HttpStatus.FORBIDDEN, "P001", "강퇴된 밥모임에는 신청서를 작성할 수 없습니다."),
+
 	// Auth
 	INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "A001", "유효하지 않은 토큰입니다."),
 	EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, "A002", "만료된 토큰입니다."),

--- a/src/test/java/com/prgrms/mukvengers/domain/proposal/service/ProposalServiceImplTest.java
+++ b/src/test/java/com/prgrms/mukvengers/domain/proposal/service/ProposalServiceImplTest.java
@@ -1,11 +1,13 @@
 package com.prgrms.mukvengers.domain.proposal.service;
 
+import static com.prgrms.mukvengers.domain.proposal.service.ProposalServiceImpl.*;
 import static com.prgrms.mukvengers.utils.CrewObjectProvider.*;
 import static com.prgrms.mukvengers.utils.ProposalObjectProvider.*;
 import static com.prgrms.mukvengers.utils.UserObjectProvider.*;
 import static org.assertj.core.api.Assertions.*;
 
 import java.util.List;
+import java.util.Optional;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -13,11 +15,139 @@ import org.junit.jupiter.api.Test;
 import com.prgrms.mukvengers.base.ServiceTest;
 import com.prgrms.mukvengers.domain.crew.model.Crew;
 import com.prgrms.mukvengers.domain.crew.model.vo.CrewStatus;
+import com.prgrms.mukvengers.domain.crewmember.model.CrewMember;
+import com.prgrms.mukvengers.domain.crewmember.model.vo.CrewMemberRole;
+import com.prgrms.mukvengers.domain.proposal.dto.request.CreateProposalRequest;
 import com.prgrms.mukvengers.domain.proposal.dto.response.ProposalResponses;
 import com.prgrms.mukvengers.domain.proposal.model.Proposal;
 import com.prgrms.mukvengers.domain.user.model.User;
+import com.prgrms.mukvengers.global.common.dto.IdResponse;
+import com.prgrms.mukvengers.utils.CrewMemberObjectProvider;
+import com.prgrms.mukvengers.utils.ProposalObjectProvider;
 
 class ProposalServiceImplTest extends ServiceTest {
+
+	@Test
+	@DisplayName("[성공] 사용자는 신청서를 작성할 수 있다.")
+	void createProposal_success() {
+
+		//given
+		User createUser = createUser("12121212");
+		User leader = userRepository.save(createUser);
+
+		Crew createCrew = createCrew(savedStore, CrewStatus.RECRUITING);
+		Crew crew = crewRepository.save(createCrew);
+
+		CreateProposalRequest proposalRequest = ProposalObjectProvider.createProposalRequest(leader.getId());
+
+		// when
+		IdResponse response = proposalService.create(proposalRequest, savedUserId, crew.getId());
+
+		// then
+		Optional<Proposal> findProposal = proposalRepository.findById(response.id());
+		assertThat(findProposal).isPresent();
+		assertThat(findProposal.get())
+			.hasFieldOrPropertyWithValue("user", savedUser)
+			.hasFieldOrPropertyWithValue("leaderId", leader.getId())
+			.hasFieldOrPropertyWithValue("crewId", crew.getId())
+			.hasFieldOrPropertyWithValue("content", proposalRequest.content());
+	}
+
+	@Test
+	@DisplayName("[실패] 모집 정원이 다 찬 밥모임에는 신청서를 작성할 수 없다.")
+	void createProposal_fail_countOverCapacity() {
+
+		//given
+		User createUser = createUser("12121212");
+		User leader = userRepository.save(createUser);
+
+		Crew createCrew = createCrew(savedStore, CrewStatus.RECRUITING);
+		Crew crew = crewRepository.save(createCrew);
+
+		CrewMember createCrewMember = CrewMemberObjectProvider.createCrewMember(leader.getId(), crew, CrewMemberRole.LEADER);
+		crewMemberRepository.save(createCrewMember);
+
+		List<CrewMember> crewMembers = CrewMemberObjectProvider.createCrewMembers(savedUserId, crew, CrewMemberRole.MEMBER,
+			crew.getCapacity());
+
+		crewMemberRepository.saveAll(crewMembers);
+
+		CreateProposalRequest proposalRequest = ProposalObjectProvider.createProposalRequest(leader.getId());
+
+		// when & then
+		assertThatThrownBy
+			(
+				() -> proposalService.create(proposalRequest, savedUserId, crew.getId())
+			)
+			.isInstanceOf(IllegalStateException.class)
+			.hasMessageContaining(CREW_MEMBER_COUNT_OVER_CAPACITY_EXCEPTION_MESSAGE);
+	}
+
+	@Test
+	@DisplayName("[실패] 해당 밥모임에 강퇴된 사용자라면 신청서를 작성할 수 없다.")
+	void createProposal_fail_blockedUser() {
+
+		//given
+		Crew createCrew = createCrew(savedStore, CrewStatus.RECRUITING);
+		Crew crew = crewRepository.save(createCrew);
+
+		CrewMember createCrewMember = CrewMemberObjectProvider.createCrewMember(savedUserId, crew, CrewMemberRole.BLOCKED);
+		crewMemberRepository.save(createCrewMember);
+
+		CreateProposalRequest proposalRequest = ProposalObjectProvider.createProposalRequest(savedUserId);
+
+		// when & then
+		assertThatThrownBy
+			(
+				() -> proposalService.create(proposalRequest, savedUserId, crew.getId())
+			)
+			.isInstanceOf(IllegalStateException.class)
+			.hasMessageContaining(DISMISSED_USER_EXCEPTION_MESSAGE);
+	}
+
+	@Test
+	@DisplayName("[실패] 사용자가 해당 밥모임의 리더라면 신청서를 작성할 수 없다.")
+	void createProposal_fail_LeaderUser() {
+
+		//given
+		Crew createCrew = createCrew(savedStore, CrewStatus.RECRUITING);
+		Crew crew = crewRepository.save(createCrew);
+
+		CrewMember createCrewMember = CrewMemberObjectProvider.createCrewMember(savedUserId, crew, CrewMemberRole.LEADER);
+		crewMemberRepository.save(createCrewMember);
+
+		CreateProposalRequest proposalRequest = ProposalObjectProvider.createProposalRequest(savedUserId);
+
+		// when & then
+		assertThatThrownBy
+			(
+				() -> proposalService.create(proposalRequest, savedUserId, crew.getId())
+			)
+			.isInstanceOf(IllegalStateException.class)
+			.hasMessageContaining(LEADER_USER_EXCEPTION_MESSAGE);
+	}
+
+	@Test
+	@DisplayName("[실패] 사용자가 이미 해당 밥모임에 참여자라면 신청서를 작성할 수 없다.")
+	void createProposal_fail_DuplicatedUser() {
+
+		//given
+		Crew createCrew = createCrew(savedStore, CrewStatus.RECRUITING);
+		Crew crew = crewRepository.save(createCrew);
+
+		CrewMember createCrewMember = CrewMemberObjectProvider.createCrewMember(savedUserId, crew, CrewMemberRole.MEMBER);
+		crewMemberRepository.save(createCrewMember);
+
+		CreateProposalRequest proposalRequest = ProposalObjectProvider.createProposalRequest(savedUserId);
+
+		// when & then
+		assertThatThrownBy
+			(
+				() -> proposalService.create(proposalRequest, savedUserId, crew.getId())
+			)
+			.isInstanceOf(IllegalStateException.class)
+			.hasMessageContaining(DUPLICATE_USER_EXCEPTION_MESSAGE);
+	}
 
 	@Test
 	@DisplayName("[성공] 사용자가 방장인 모임의 모든 신청서를 조회한다.")
@@ -41,7 +171,7 @@ class ProposalServiceImplTest extends ServiceTest {
 	}
 
 	@Test
-	@DisplayName("[성공] 사용자가 방장인 아니고 참여자인 모임의 신청서를 모두 조회합니다.")
+	@DisplayName("[성공] 사용자가 방장인 아니고 참여자인 밥모임의 신청서를 모두 조회합니다.")
 	void getProposalsByMemberId_success() {
 
 		//given

--- a/src/test/java/com/prgrms/mukvengers/utils/CrewMemberObjectProvider.java
+++ b/src/test/java/com/prgrms/mukvengers/utils/CrewMemberObjectProvider.java
@@ -1,5 +1,9 @@
 package com.prgrms.mukvengers.utils;
 
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
 import com.prgrms.mukvengers.domain.crew.model.Crew;
 import com.prgrms.mukvengers.domain.crewmember.model.CrewMember;
 import com.prgrms.mukvengers.domain.crewmember.model.vo.CrewMemberRole;
@@ -13,5 +17,11 @@ public class CrewMemberObjectProvider {
 			.crew(crew)
 			.crewMemberRole(crewMemberRole)
 			.build();
+	}
+
+	public static List<CrewMember> createCrewMembers(Long userId, Crew crew, CrewMemberRole role, Integer capacity) {
+
+		return IntStream.range(1, capacity)
+			.mapToObj(i -> createCrewMember(userId, crew, role)).collect(Collectors.toList());
 	}
 }

--- a/src/test/java/com/prgrms/mukvengers/utils/ProposalObjectProvider.java
+++ b/src/test/java/com/prgrms/mukvengers/utils/ProposalObjectProvider.java
@@ -4,6 +4,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
+import com.prgrms.mukvengers.domain.proposal.dto.request.CreateProposalRequest;
 import com.prgrms.mukvengers.domain.proposal.model.Proposal;
 import com.prgrms.mukvengers.domain.user.model.User;
 
@@ -24,5 +25,9 @@ public class ProposalObjectProvider {
 		return IntStream.range(0, 20)
 			.mapToObj(i -> createProposal(user, leaderId, crewId))
 			.collect(Collectors.toList());
+	}
+
+	public static CreateProposalRequest createProposalRequest(Long userId) {
+		return new CreateProposalRequest(userId, CONTENT);
 	}
 }


### PR DESCRIPTION
<!-- 제목은 `[#이슈번호] 제목` 으로 작성한다. ex) [#8] 결제 기능 -->

### 🌱 작업 사항 
- 신청서를 작성하는 API를 생성하였습니다.
- 신청서를 생성하기 전 `여러 검증`이 필요합니다.
  - 사용자가 존재하는 사용자인지 & 밥모임이 존재하는 밥모임인지
  - 해당 밥모임의 모집 인원이 다 차서 신청할 수 없는 경우
  - 이미 신청한 밥모임에 다시 신청서를 작성하는 경우 (중복 신청 방지)
  - 강퇴된 사용자가 해당 밥모임에 다시 신청하는 경우 (강퇴 유저)
  - 해당 밥모임의 방장이 신청서를 작성하는 경우

- 각 검증에 대한 실패 테스트를 작성하였습니다.
 
### ❓ 리뷰 포인트
- CrewMemberRole에 따른 검증은 `메시지만 다르지 똑같은 예외`가 터지는 것이라 생각해 `IllegalStateException` 처리한 상태입니다. 
따로 Custom Exception으로 처리하는 것이 좋을까요? 그렇다면 총 Exception 클래스는 4개가 나올 것으로 예상되며
 [feat: Custom Exception 으로 변경시 사용될 ErrorCode](https://github.com/prgrms-web-devcourse/Team-Kkini-Mukvengers-BE/commit/228e75cd3b6392245b7b02f83837ad1b132b20ba) 처럼 `HttpStatus.FORBIDDEN` 상태 코드를 두려고 하는데 어떻게 생각하시나요?
- 혹시 제가 빠트린 다른 검증 로직이 있을까요?

### 🦄 관련 이슈
resolves #126 


