### PR TITLE
[#127] 모임 단건 조회 응답 DTO 수정

### DIFF
--- a/src/main/java/com/prgrms/mukvengers/domain/crew/dto/response/CrewDetailResponse.java
+++ b/src/main/java/com/prgrms/mukvengers/domain/crew/dto/response/CrewDetailResponse.java
@@ -4,9 +4,11 @@ import java.time.LocalDateTime;
 import java.util.List;
 
 import com.prgrms.mukvengers.domain.crewmember.dto.response.CrewMemberResponse;
+import com.prgrms.mukvengers.domain.store.dto.response.StoreResponse;
 
 public record CrewDetailResponse(
 	Long id,
+	StoreResponse response,
 	String name,
 	Integer currentMember,
 	Integer capacity,

--- a/src/main/java/com/prgrms/mukvengers/domain/crew/mapper/CrewMapper.java
+++ b/src/main/java/com/prgrms/mukvengers/domain/crew/mapper/CrewMapper.java
@@ -15,6 +15,7 @@ import com.prgrms.mukvengers.domain.crew.dto.response.CrewLocationResponse;
 import com.prgrms.mukvengers.domain.crew.dto.response.CrewResponse;
 import com.prgrms.mukvengers.domain.crew.model.Crew;
 import com.prgrms.mukvengers.domain.crewmember.dto.response.CrewMemberResponse;
+import com.prgrms.mukvengers.domain.store.dto.response.StoreResponse;
 import com.prgrms.mukvengers.domain.store.model.Store;
 
 @Mapper(componentModel = "spring", unmappedSourcePolicy = IGNORE)
@@ -29,9 +30,11 @@ public interface CrewMapper {
 	@Mapping(target = "promiseTime", source = "crew.promiseTime")
 	CrewResponse toCrewResponse(Crew crew, Integer currentMember);
 
+	@Mapping(target = "response", source = "storeResponse")
 	@Mapping(target = "promiseTime", source = "crew.promiseTime")
-	CrewDetailResponse toCrewAndCrewMemberResponse(Crew crew, Integer currentMember,
-		List<CrewMemberResponse> members);
+	@Mapping(target = "id", source = "crew.id")
+	CrewDetailResponse toCrewDetailResponse(Crew crew, Integer currentMember,
+		List<CrewMemberResponse> members, StoreResponse storeResponse);
 
 	@Mapping(target = "latitude", source = "location", qualifiedByName = "latitudeMethod")
 	@Mapping(target = "longitude", source = "location", qualifiedByName = "longitudeMethod")
@@ -39,12 +42,12 @@ public interface CrewMapper {
 
 	@Named("latitudeMethod")
 	default Double mapLatitude(Point location) {
-		return location.getX();
+		return location.getY();
 	}
 
 	@Named("longitudeMethod")
 	default Double mapLongitude(Point location) {
-		return location.getY();
+		return location.getX();
 	}
 }
 

--- a/src/main/java/com/prgrms/mukvengers/domain/crew/service/CrewServiceImpl.java
+++ b/src/main/java/com/prgrms/mukvengers/domain/crew/service/CrewServiceImpl.java
@@ -30,7 +30,6 @@ import com.prgrms.mukvengers.domain.store.mapper.StoreMapper;
 import com.prgrms.mukvengers.domain.store.model.Store;
 import com.prgrms.mukvengers.domain.store.repository.StoreRepository;
 import com.prgrms.mukvengers.domain.user.exception.UserNotFoundException;
-import com.prgrms.mukvengers.domain.user.model.User;
 import com.prgrms.mukvengers.domain.user.repository.UserRepository;
 import com.prgrms.mukvengers.global.common.dto.IdResponse;
 
@@ -72,7 +71,7 @@ public class CrewServiceImpl implements CrewService {
 
 		List<CrewDetailResponse> responses = crewMemberRepository.findAllByUserIdOrderByStatus(userId)
 			.stream()
-			.map(crew -> crewMapper.toCrewAndCrewMemberResponse(
+			.map(crew -> crewMapper.toCrewDetailResponse(
 				crew,
 				crewMemberRepository.countCrewMemberByCrewId(crew.getId()), crewMemberRepository.findAllByCrewId(
 						crew.getId())
@@ -81,11 +80,8 @@ public class CrewServiceImpl implements CrewService {
 						userRepository.findById(CrewMember.getUserId())
 							.orElseThrow(() -> new UserNotFoundException(CrewMember.getUserId())),
 						CrewMember.getCrewMemberRole()))
-					.toList()))
+					.toList(), storeMapper.toStoreResponse(crew.getStore())))
 			.toList();
-
-		User user = userRepository.findById(userId)
-			.orElseThrow(() -> new UserNotFoundException(userId));
 
 		return new CrewResponses(responses);
 	}
@@ -106,14 +102,15 @@ public class CrewServiceImpl implements CrewService {
 				CrewMember.getCrewMemberRole()))
 			.toList();
 
-		return crewMapper.toCrewAndCrewMemberResponse(crew, currentMember, members);
+		return crewMapper.toCrewDetailResponse(crew, currentMember, members,
+			storeMapper.toStoreResponse(crew.getStore()));
 	}
 
 	@Override
 	public CrewPageResponse getByPlaceId(String placeId, Pageable pageable) {
 
 		Page<CrewDetailResponse> responses = crewRepository.findAllByPlaceId(placeId, pageable)
-			.map(crew -> crewMapper.toCrewAndCrewMemberResponse(crew,
+			.map(crew -> crewMapper.toCrewDetailResponse(crew,
 				crewMemberRepository.countCrewMemberByCrewId(crew.getId())
 				, crewMemberRepository.findAllByCrewId(crew.getId())
 					.stream()
@@ -121,7 +118,7 @@ public class CrewServiceImpl implements CrewService {
 						userRepository.findById(CrewMember.getUserId())
 							.orElseThrow(() -> new UserNotFoundException(CrewMember.getUserId())),
 						CrewMember.getCrewMemberRole()))
-					.toList()));
+					.toList(), storeMapper.toStoreResponse(crew.getStore())));
 
 		return new CrewPageResponse(responses);
 	}

--- a/src/test/java/com/prgrms/mukvengers/domain/crew/api/CrewControllerTest.java
+++ b/src/test/java/com/prgrms/mukvengers/domain/crew/api/CrewControllerTest.java
@@ -135,7 +135,20 @@ class CrewControllerTest extends ControllerTest {
 							fieldWithPath("data.members.[].userId").type(NUMBER).description("유저 ID"),
 							fieldWithPath("data.members.[].nickname").type(STRING).description("닉네임"),
 							fieldWithPath("data.members.[].profileImgUrl").type(STRING).description("프로필 이미지"),
-							fieldWithPath("data.members.[].crewMemberRole").type(STRING).description("사용자의 권한"))
+							fieldWithPath("data.members.[].crewMemberRole").type(STRING).description("사용자의 권한"),
+							fieldWithPath("data.response.id").type(NUMBER).description("가게 아이디"),
+							fieldWithPath("data.response.latitude").type(NUMBER).description("위도"),
+							fieldWithPath("data.response.longitude").type(NUMBER).description("경도"),
+							fieldWithPath("data.response.placeId").type(STRING)
+								.description("지도 api 제공 id"),
+							fieldWithPath("data.response.placeName").type(STRING).description("가게 이름"),
+							fieldWithPath("data.response.categories").type(STRING).description("가게 카테고리"),
+							fieldWithPath("data.response.roadAddressName").type(STRING)
+								.description("가게 도로명 주소"),
+							fieldWithPath("data.response.photoUrls").type(STRING).description("가게 사진 URL"),
+							fieldWithPath("data.response.kakaoPlaceUrl").type(STRING)
+								.description("가게 상세 페이지 URL"),
+							fieldWithPath("data.response.phoneNumber").type(STRING).description("가게 전화번호"))
 						.build()
 				)
 			));
@@ -183,7 +196,20 @@ class CrewControllerTest extends ControllerTest {
 							fieldWithPath("data.responses.[].members.[].profileImgUrl").type(STRING)
 								.description("프로필 이미지"),
 							fieldWithPath("data.responses.[].members.[].crewMemberRole").type(STRING)
-								.description("사용자의 권한"))
+								.description("사용자의 권한"),
+							fieldWithPath("data.responses.[].response.id").type(NUMBER).description("가게 아이디"),
+							fieldWithPath("data.responses.[].response.latitude").type(NUMBER).description("위도"),
+							fieldWithPath("data.responses.[].response.longitude").type(NUMBER).description("경도"),
+							fieldWithPath("data.responses.[].response.placeId").type(STRING)
+								.description("지도 api 제공 id"),
+							fieldWithPath("data.responses.[].response.placeName").type(STRING).description("가게 이름"),
+							fieldWithPath("data.responses.[].response.categories").type(STRING).description("가게 카테고리"),
+							fieldWithPath("data.responses.[].response.roadAddressName").type(STRING)
+								.description("가게 도로명 주소"),
+							fieldWithPath("data.responses.[].response.photoUrls").type(STRING).description("가게 사진 URL"),
+							fieldWithPath("data.responses.[].response.kakaoPlaceUrl").type(STRING)
+								.description("가게 상세 페이지 URL"),
+							fieldWithPath("data.responses.[].response.phoneNumber").type(STRING).description("가게 전화번호"))
 						.build()
 				)
 			));
@@ -267,7 +293,25 @@ class CrewControllerTest extends ControllerTest {
 							fieldWithPath("data.responses.numberOfElements").type(NUMBER).description("페이지 원소 개수"),
 							fieldWithPath("data.responses.empty").type(BOOLEAN).description("빈 페이지 여부"),
 							fieldWithPath("data.responses.totalPages").type(NUMBER).description("전체 페이지 개수"),
-							fieldWithPath("data.responses.totalElements").type(NUMBER).description("전체 데이터 개수"))
+							fieldWithPath("data.responses.totalElements").type(NUMBER).description("전체 데이터 개수"),
+							fieldWithPath("data.responses.content.[].response.id").type(NUMBER).description("가게 아이디"),
+							fieldWithPath("data.responses.content.[].response.latitude").type(NUMBER).description("위도"),
+							fieldWithPath("data.responses.content.[].response.longitude").type(NUMBER)
+								.description("경도"),
+							fieldWithPath("data.responses.content.[].response.placeId").type(STRING)
+								.description("지도 api 제공 id"),
+							fieldWithPath("data.responses.content.[].response.placeName").type(STRING)
+								.description("가게 이름"),
+							fieldWithPath("data.responses.content.[].response.categories").type(STRING)
+								.description("가게 카테고리"),
+							fieldWithPath("data.responses.content.[].response.roadAddressName").type(STRING)
+								.description("가게 도로명 주소"),
+							fieldWithPath("data.responses.content.[].response.photoUrls").type(STRING)
+								.description("가게 사진 URL"),
+							fieldWithPath("data.responses.content.[].response.kakaoPlaceUrl").type(STRING)
+								.description("가게 상세 페이지 URL"),
+							fieldWithPath("data.responses.content.[].response.phoneNumber").type(STRING)
+								.description("가게 전화번호"))
 						.build()
 				)
 			));


### PR DESCRIPTION
### 🌱 작업 사항 
- 프론트의 요청으로 가게의 모임조회, 사용자가 참여한 모임 조회, 모임 단건 조회 응답에 가게 정보도 같이 반환합니다.
- CrewDetailResponse에서 StoreResponse 필드 추가
### ❓ 리뷰 포인트
- DTO 수정에 요청이 계속 오는데 변화에 잘 대응하지 못하는 것 같습니다.
- 리스트를 일급컬렉션으로 만들어 반환하고 있는데 컬렉션을 한번 Wrapping하는 것이 옳은 것인지 모르겠습니다. 팀원분들의 생각이 궁금합니다.
### 🦄 관련 이슈
resolves #127 



