### PR TITLE
[#38] Cookie httpOnly 속성 변경

### DIFF
--- a/src/main/java/com/prgrms/mukvengers/global/security/oauth/handler/OAuthAuthenticationSuccessHandler.java
+++ b/src/main/java/com/prgrms/mukvengers/global/security/oauth/handler/OAuthAuthenticationSuccessHandler.java
@@ -67,7 +67,7 @@ public class OAuthAuthenticationSuccessHandler
 		ResponseCookie token = ResponseCookie.from("refreshToken", refreshToken)
 			.path(getDefaultTargetUrl())
 			.sameSite("None")
-			.httpOnly(true)
+			.httpOnly(false)
 			.secure(true)
 			.maxAge(tokenService.getRefreshTokenExpirySeconds())
 			.build();

--- a/src/main/java/com/prgrms/mukvengers/global/security/token/api/TokenController.java
+++ b/src/main/java/com/prgrms/mukvengers/global/security/token/api/TokenController.java
@@ -2,6 +2,7 @@ package com.prgrms.mukvengers.global.security.token.api;
 
 import static org.springframework.http.HttpHeaders.*;
 
+import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.CookieValue;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -11,6 +12,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.prgrms.mukvengers.global.security.token.dto.response.TokenResponse;
 import com.prgrms.mukvengers.global.security.token.service.TokenService;
+import com.prgrms.mukvengers.global.utils.CookieUtil;
 
 import lombok.RequiredArgsConstructor;
 
@@ -37,7 +39,9 @@ public class TokenController {
 	) {
 		tokenService.deleteRefreshToken(refreshToken);
 
+		ResponseCookie emptyCookie = CookieUtil.getEmptyCookie("refreshToken");
+
 		return ResponseEntity.noContent()
-			.header(SET_COOKIE, "").build();
+			.header(SET_COOKIE, emptyCookie.toString()).build();
 	}
 }

--- a/src/main/java/com/prgrms/mukvengers/global/utils/CookieUtil.java
+++ b/src/main/java/com/prgrms/mukvengers/global/utils/CookieUtil.java
@@ -10,6 +10,7 @@ import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import org.springframework.http.ResponseCookie;
 import org.springframework.util.SerializationUtils;
 
 import lombok.NoArgsConstructor;
@@ -33,7 +34,8 @@ public class CookieUtil {
 	public static void addCookie(HttpServletResponse response, String name, String value, int maxAge) {
 		Cookie cookie = new Cookie(name, value);
 		cookie.setPath("/");
-		cookie.setHttpOnly(true);
+		cookie.setHttpOnly(false);
+		cookie.setSecure(true);
 		cookie.setMaxAge(maxAge);
 		response.addCookie(cookie);
 	}
@@ -53,6 +55,16 @@ public class CookieUtil {
 					response.addCookie(cookie);
 				});
 		}
+	}
+
+	public static ResponseCookie getEmptyCookie(String key) {
+		return ResponseCookie.from(key, "")
+			.path("/")
+			.sameSite("None")
+			.httpOnly(false)
+			.secure(true)
+			.maxAge(0)
+			.build();
 	}
 
 	public static String serialize(Object object) {


### PR DESCRIPTION
### 🌱 작업 사항 
#### 프론트의 요청 사항에 따라 Cookie의 httpOnly 속성을 false로 설정하였습니다.
- httpOnly 속성은 브라우저에서 Cookie정보를 사용할 수 있게 하는 옵션입니다. false로 설정할 경우 브라우저(JS)에서 Cookie 값을 사용할 수 있습니다. 그렇게 된다면 악의적인 크롤러에 의해서도 탈취되거나 사용할 수 있게 되기 때문에 별로 좋지 않습니다. 물론, secure 속성은 true이기 때문에 암호화 되어 있습니다. 그럼에도, 위험하기 때문에 추후에 LocalStorage를 이용할 수 있는 방법을 적용해볼 수 있도록 하겠습니다.

### ❓ 리뷰 포인트

### 🦄 관련 이슈
- #38 


