### PR TITLE
[#135] 모집 상태 변경(모집 종료-> 식사 완료) 기능

### DIFF
--- a/src/main/java/com/prgrms/mukvengers/domain/crew/api/CrewController.java
+++ b/src/main/java/com/prgrms/mukvengers/domain/crew/api/CrewController.java
@@ -133,7 +133,7 @@ public class CrewController {
 	 * <pre>
 	 *     밥 모임 모집 종료로 상태 변경
 	 * </pre>
-	 * @param crewId 밤 모임 아이디와
+	 * @param crewId 밤 모임 아이디와 모임 아이디
 	 * @param user 사용자 정보
 	 * @return status : 200
 	 */
@@ -144,6 +144,24 @@ public class CrewController {
 		@AuthenticationPrincipal JwtAuthentication user
 	) {
 		crewService.closeStatus(crewId, user.id());
+		return ResponseEntity.ok().build();
+	}
+
+	/**
+	 * <pre>
+	 *     밥 모임 모집 종료로 상태 변경
+	 * </pre>
+	 * @param crewId 밤 모임 아이디와 모임 아이디
+	 * @param user 사용자 정보
+	 * @return status : 200
+	 */
+	@PatchMapping(value = "/{crewId}/finish")
+	public ResponseEntity<Void> finishStatus
+	(
+		@PathVariable Long crewId,
+		@AuthenticationPrincipal JwtAuthentication user
+	) {
+		crewService.finishStatus(crewId, user.id());
 		return ResponseEntity.ok().build();
 	}
 

--- a/src/main/java/com/prgrms/mukvengers/domain/crew/api/CrewController.java
+++ b/src/main/java/com/prgrms/mukvengers/domain/crew/api/CrewController.java
@@ -18,6 +18,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.util.UriComponentsBuilder;
 
@@ -28,6 +29,7 @@ import com.prgrms.mukvengers.domain.crew.dto.response.CrewLocationResponses;
 import com.prgrms.mukvengers.domain.crew.dto.response.CrewPageResponse;
 import com.prgrms.mukvengers.domain.crew.dto.response.CrewResponses;
 import com.prgrms.mukvengers.domain.crew.facade.CrewFacadeService;
+import com.prgrms.mukvengers.domain.crew.model.vo.CrewStatus;
 import com.prgrms.mukvengers.domain.crew.service.CrewService;
 import com.prgrms.mukvengers.global.common.dto.ApiResponse;
 import com.prgrms.mukvengers.global.common.dto.IdResponse;
@@ -133,35 +135,19 @@ public class CrewController {
 	 * <pre>
 	 *     밥 모임 모집 종료로 상태 변경
 	 * </pre>
-	 * @param crewId 밤 모임 아이디와 모임 아이디
+	 * @param crewId 밤 모임 아이디
+	 * @param crewStatus 변경할 모임 상태
 	 * @param user 사용자 정보
 	 * @return status : 200
 	 */
-	@PatchMapping(value = "/{crewId}/close")
-	public ResponseEntity<Void> closeStatus
+	@PatchMapping(value = "/{crewId}")
+	public ResponseEntity<Void> updateStatus
 	(
 		@PathVariable Long crewId,
+		@RequestParam CrewStatus crewStatus,
 		@AuthenticationPrincipal JwtAuthentication user
 	) {
-		crewService.closeStatus(crewId, user.id());
-		return ResponseEntity.ok().build();
-	}
-
-	/**
-	 * <pre>
-	 *     밥 모임 모집 종료로 상태 변경
-	 * </pre>
-	 * @param crewId 밤 모임 아이디와 모임 아이디
-	 * @param user 사용자 정보
-	 * @return status : 200
-	 */
-	@PatchMapping(value = "/{crewId}/finish")
-	public ResponseEntity<Void> finishStatus
-	(
-		@PathVariable Long crewId,
-		@AuthenticationPrincipal JwtAuthentication user
-	) {
-		crewService.finishStatus(crewId, user.id());
+		crewService.updateStatus(crewId, user.id(), crewStatus);
 		return ResponseEntity.ok().build();
 	}
 

--- a/src/main/java/com/prgrms/mukvengers/domain/crew/dto/request/UpdateStatusRequest.java
+++ b/src/main/java/com/prgrms/mukvengers/domain/crew/dto/request/UpdateStatusRequest.java
@@ -1,8 +1,0 @@
-package com.prgrms.mukvengers.domain.crew.dto.request;
-
-import javax.validation.constraints.NotNull;
-
-public record UpdateStatusRequest(
-	@NotNull Long crewId
-) {
-}

--- a/src/main/java/com/prgrms/mukvengers/domain/crew/service/CrewService.java
+++ b/src/main/java/com/prgrms/mukvengers/domain/crew/service/CrewService.java
@@ -8,6 +8,7 @@ import com.prgrms.mukvengers.domain.crew.dto.response.CrewDetailResponse;
 import com.prgrms.mukvengers.domain.crew.dto.response.CrewLocationResponses;
 import com.prgrms.mukvengers.domain.crew.dto.response.CrewPageResponse;
 import com.prgrms.mukvengers.domain.crew.dto.response.CrewResponses;
+import com.prgrms.mukvengers.domain.crew.model.vo.CrewStatus;
 import com.prgrms.mukvengers.global.common.dto.IdResponse;
 
 public interface CrewService {
@@ -22,7 +23,5 @@ public interface CrewService {
 
 	CrewLocationResponses getByLocation(SearchCrewRequest distanceRequest);
 
-	void closeStatus(Long crewId, Long userId);
-
-	void finishStatus(Long crewId, Long userId);
+	void updateStatus(Long crewId, Long userId, CrewStatus crewStatus);
 }

--- a/src/main/java/com/prgrms/mukvengers/domain/crew/service/CrewService.java
+++ b/src/main/java/com/prgrms/mukvengers/domain/crew/service/CrewService.java
@@ -24,4 +24,5 @@ public interface CrewService {
 
 	void closeStatus(Long crewId, Long userId);
 
+	void finishStatus(Long crewId, Long userId);
 }

--- a/src/main/java/com/prgrms/mukvengers/domain/crew/service/CrewServiceImpl.java
+++ b/src/main/java/com/prgrms/mukvengers/domain/crew/service/CrewServiceImpl.java
@@ -164,4 +164,24 @@ public class CrewServiceImpl implements CrewService {
 
 	}
 
+	@Override
+	public void finishStatus(Long crewId, Long userId) {
+
+		Crew crew = crewRepository.findById(crewId)
+			.orElseThrow(() -> new CrewNotFoundException(crewId));
+
+		CrewMember crewMember = crewMemberRepository.findCrewMemberByCrewIdAndUserId(crewId, userId)
+			.orElseThrow(() -> new MemberNotFoundException(userId));
+
+		if (!crewMember.getCrewMemberRole().equals(CrewMemberRole.LEADER)) {
+			throw new NotLeaderException(CrewMemberRole.LEADER);
+		}
+
+		if (!crew.getStatus().equals(CrewStatus.CLOSE)) {
+			throw new CrewStatusException(crew.getStatus());
+		}
+
+		crew.changeStatus(CrewStatus.FINISH);
+
+	}
 }

--- a/src/main/java/com/prgrms/mukvengers/domain/crew/service/CrewServiceImpl.java
+++ b/src/main/java/com/prgrms/mukvengers/domain/crew/service/CrewServiceImpl.java
@@ -144,7 +144,7 @@ public class CrewServiceImpl implements CrewService {
 	}
 
 	@Override
-	public void closeStatus(Long crewId, Long userId) {
+	public void updateStatus(Long crewId, Long userId, CrewStatus crewStatus) {
 
 		Crew crew = crewRepository.findById(crewId)
 			.orElseThrow(() -> new CrewNotFoundException(crewId));
@@ -156,29 +156,22 @@ public class CrewServiceImpl implements CrewService {
 			throw new NotLeaderException(CrewMemberRole.LEADER);
 		}
 
-		if (!crew.getStatus().equals(CrewStatus.RECRUITING)) {
-			throw new CrewStatusException(crew.getStatus());
-		}
+		switch (crewStatus) {
+			case CLOSE -> {
+				if (!crew.getStatus().equals(CrewStatus.RECRUITING)) {
+					throw new CrewStatusException(crew.getStatus());
+				}
+			}
 
-		crew.changeStatus(CrewStatus.CLOSE);
+			case FINISH -> {
+				if (!crew.getStatus().equals(CrewStatus.CLOSE)) {
+					throw new CrewStatusException(crew.getStatus());
+				}
+			}
 
-	}
-
-	@Override
-	public void finishStatus(Long crewId, Long userId) {
-
-		Crew crew = crewRepository.findById(crewId)
-			.orElseThrow(() -> new CrewNotFoundException(crewId));
-
-		CrewMember crewMember = crewMemberRepository.findCrewMemberByCrewIdAndUserId(crewId, userId)
-			.orElseThrow(() -> new MemberNotFoundException(userId));
-
-		if (!crewMember.getCrewMemberRole().equals(CrewMemberRole.LEADER)) {
-			throw new NotLeaderException(CrewMemberRole.LEADER);
-		}
-
-		if (!crew.getStatus().equals(CrewStatus.CLOSE)) {
-			throw new CrewStatusException(crew.getStatus());
+			default -> {
+				throw new CrewStatusException(crewStatus);
+			}
 		}
 
 		crew.changeStatus(CrewStatus.FINISH);

--- a/src/main/java/com/prgrms/mukvengers/domain/crew/service/CrewServiceImpl.java
+++ b/src/main/java/com/prgrms/mukvengers/domain/crew/service/CrewServiceImpl.java
@@ -144,7 +144,7 @@ public class CrewServiceImpl implements CrewService {
 	}
 
 	@Override
-  @Transactional
+	@Transactional
 	public void updateStatus(Long crewId, Long userId, CrewStatus crewStatus) {
 
 		Crew crew = crewRepository.findById(crewId)

--- a/src/test/java/com/prgrms/mukvengers/domain/crew/api/CrewControllerTest.java
+++ b/src/test/java/com/prgrms/mukvengers/domain/crew/api/CrewControllerTest.java
@@ -25,7 +25,6 @@ import com.epages.restdocs.apispec.Schema;
 import com.prgrms.mukvengers.base.ControllerTest;
 import com.prgrms.mukvengers.domain.crew.dto.request.CreateCrewRequest;
 import com.prgrms.mukvengers.domain.crew.model.Crew;
-import com.prgrms.mukvengers.domain.crew.model.vo.CrewStatus;
 import com.prgrms.mukvengers.domain.crewmember.model.CrewMember;
 import com.prgrms.mukvengers.domain.crewmember.model.vo.CrewMemberRole;
 import com.prgrms.mukvengers.utils.CrewMemberObjectProvider;
@@ -368,7 +367,7 @@ class CrewControllerTest extends ControllerTest {
 
 	@Test
 	@DisplayName("[성공] 모임 상태를 모집 중 -> 모집 완료로 변경한다.")
-	void closeStatus_success() throws Exception {
+	void updateStatus_success() throws Exception {
 
 		Crew crew = CrewObjectProvider.createCrew(savedStore);
 
@@ -378,51 +377,25 @@ class CrewControllerTest extends ControllerTest {
 
 		crewMemberRepository.save(crewMember);
 
-		mockMvc.perform(patch("/api/v1/crews/{crewId}/close", crew.getId())
+		MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+		params.add("crewStatus", "CLOSE");
+
+		mockMvc.perform(patch("/api/v1/crews/{crewId}", crew.getId())
+				.params(params)
 				.contentType(APPLICATION_JSON)
 				.header(AUTHORIZATION, BEARER_TYPE + accessToken))
 			.andExpect(status().isOk())
 			.andDo(print())
-			.andDo(document("crew-closeStatus",
+			.andDo(document("crew-updateStatus",
 				resource(
 					builder()
 						.tag(CREW)
-						.summary("모임 상태 모집 중 -> 모집 완료 변경 API")
-						.description("모집 중인 상태를 모집 완료 상태로 변경합니다.")
+						.summary("모임 상태 변경")
+						.description("모임 상태를 변경합니다.")
 						.build()
 				)
 			));
 
 	}
 
-	@Test
-	@DisplayName("[성공] 모임 상태를 모집 완료 -> 식사 완료로 변경한다.")
-	void finishStatus_success() throws Exception {
-
-		Crew crew = CrewObjectProvider.createCrew(savedStore);
-
-		crew.changeStatus(CrewStatus.CLOSE);
-
-		crewRepository.save(crew);
-
-		CrewMember crewMember = createCrewMember(savedUserId, crew, CrewMemberRole.LEADER);
-
-		crewMemberRepository.save(crewMember);
-
-		mockMvc.perform(patch("/api/v1/crews/{crewId}/finish", crew.getId())
-				.contentType(APPLICATION_JSON)
-				.header(AUTHORIZATION, BEARER_TYPE + accessToken))
-			.andExpect(status().isOk())
-			.andDo(print())
-			.andDo(document("crew-finishStatus",
-				resource(
-					builder()
-						.tag(CREW)
-						.summary("모임 상태 모집 완료 -> 식사 완료 변경 API")
-						.description("모집 완료인 상태를 식사 완료 상태로 변경합니다.")
-						.build()
-				)
-			));
-
-	}
 }

--- a/src/test/java/com/prgrms/mukvengers/domain/crew/service/CrewServiceImplTest.java
+++ b/src/test/java/com/prgrms/mukvengers/domain/crew/service/CrewServiceImplTest.java
@@ -160,33 +160,7 @@ class CrewServiceImplTest extends ServiceTest {
 		crewMemberRepository.save(crewMember);
 
 		//when
-		crewService.closeStatus(crew.getId(), savedUserId);
-
-		//then
-		Optional<Crew> optionalCrew = crewRepository.findById(crew.getId());
-
-		assertThat(optionalCrew).isPresent();
-		Crew savedCrew = optionalCrew.get();
-		assertThat(savedCrew.getStatus()).isEqualTo(CLOSE);
-	}
-
-	@Test
-	@DisplayName("[성공] 모임의 상태를 받아 변경한다.")
-	void finishStatus_success() {
-
-		//given
-		Crew crew = CrewObjectProvider.createCrew(savedStore);
-
-		crew.changeStatus(CLOSE);
-
-		crewRepository.save(crew);
-
-		CrewMember crewMember = createCrewMember(savedUserId, crew, CrewMemberRole.LEADER);
-
-		crewMemberRepository.save(crewMember);
-
-		//when
-		crewService.finishStatus(crew.getId(), savedUserId);
+		crewService.updateStatus(crew.getId(), savedUserId, CLOSE);
 
 		//then
 		Optional<Crew> optionalCrew = crewRepository.findById(crew.getId());

--- a/src/test/java/com/prgrms/mukvengers/domain/crew/service/CrewServiceImplTest.java
+++ b/src/test/java/com/prgrms/mukvengers/domain/crew/service/CrewServiceImplTest.java
@@ -82,7 +82,7 @@ class CrewServiceImplTest extends ServiceTest {
 	void getById_success() {
 
 		//given
-		Crew crew = CrewObjectProvider.createCrew(savedStore, RECRUITING);
+		Crew crew = CrewObjectProvider.createCrew(savedStore);
 
 		crewRepository.save(crew);
 
@@ -127,7 +127,7 @@ class CrewServiceImplTest extends ServiceTest {
 	void findByLocation_success() {
 
 		//given
-		Crew crew = CrewObjectProvider.createCrew(savedStore, RECRUITING);
+		Crew crew = CrewObjectProvider.createCrew(savedStore);
 
 		crewRepository.save(crew);
 
@@ -151,7 +151,7 @@ class CrewServiceImplTest extends ServiceTest {
 	void closeStatus_success() {
 
 		//given
-		Crew crew = CrewObjectProvider.createCrew(savedStore, RECRUITING);
+		Crew crew = CrewObjectProvider.createCrew(savedStore);
 
 		crewRepository.save(crew);
 
@@ -168,6 +168,32 @@ class CrewServiceImplTest extends ServiceTest {
 		assertThat(optionalCrew).isPresent();
 		Crew savedCrew = optionalCrew.get();
 		assertThat(savedCrew.getStatus()).isEqualTo(CLOSE);
+	}
+
+	@Test
+	@DisplayName("[성공] 모임의 상태를 받아 변경한다.")
+	void finishStatus_success() {
+
+		//given
+		Crew crew = CrewObjectProvider.createCrew(savedStore);
+
+		crew.changeStatus(CLOSE);
+
+		crewRepository.save(crew);
+
+		CrewMember crewMember = createCrewMember(savedUserId, crew, CrewMemberRole.LEADER);
+
+		crewMemberRepository.save(crewMember);
+
+		//when
+		crewService.finishStatus(crew.getId(), savedUserId);
+
+		//then
+		Optional<Crew> optionalCrew = crewRepository.findById(crew.getId());
+
+		assertThat(optionalCrew).isPresent();
+		Crew savedCrew = optionalCrew.get();
+		assertThat(savedCrew.getStatus()).isEqualTo(FINISH);
 	}
 
 }

--- a/src/test/java/com/prgrms/mukvengers/domain/crewmember/repository/CrewMemberRepositoryTest.java
+++ b/src/test/java/com/prgrms/mukvengers/domain/crewmember/repository/CrewMemberRepositoryTest.java
@@ -1,6 +1,5 @@
 package com.prgrms.mukvengers.domain.crewmember.repository;
 
-import static com.prgrms.mukvengers.domain.crew.model.vo.CrewStatus.*;
 import static com.prgrms.mukvengers.utils.CrewMemberObjectProvider.*;
 import static com.prgrms.mukvengers.utils.CrewObjectProvider.*;
 import static com.prgrms.mukvengers.utils.UserObjectProvider.*;
@@ -28,7 +27,7 @@ class CrewMemberRepositoryTest extends RepositoryTest {
 	void setCrewMember() {
 		reviewer = savedUser;
 		reviewee = userRepository.save(createUser("kakao_1212"));
-		crew = crewRepository.save(createCrew(savedStore, RECRUITING));
+		crew = crewRepository.save(createCrew(savedStore));
 	}
 
 	@Test
@@ -69,7 +68,7 @@ class CrewMemberRepositoryTest extends RepositoryTest {
 	@DisplayName("[실패] 해당 밥모임에 참여하지 않은 사용자이면 empty 반환된다.")
 	void findCrewMemberByCrewIdAndUserId_success() {
 		// given
-		Crew otherCrew = crewRepository.save(createCrew(savedStore, RECRUITING));
+		Crew otherCrew = crewRepository.save(createCrew(savedStore));
 		CrewMember crewMemberOfMember = createCrewMember(reviewee.getId(), otherCrew, CrewMemberRole.MEMBER);
 		CrewMember member = crewMemberRepository.save(crewMemberOfMember);
 		otherCrew.addCrewMember(member);

--- a/src/test/java/com/prgrms/mukvengers/domain/crewmember/service/CrewMemberServiceImplTest.java
+++ b/src/test/java/com/prgrms/mukvengers/domain/crewmember/service/CrewMemberServiceImplTest.java
@@ -1,6 +1,5 @@
 package com.prgrms.mukvengers.domain.crewmember.service;
 
-import static com.prgrms.mukvengers.domain.crew.model.vo.CrewStatus.*;
 import static com.prgrms.mukvengers.domain.crewmember.model.vo.CrewMemberRole.*;
 import static com.prgrms.mukvengers.utils.CrewObjectProvider.*;
 import static org.assertj.core.api.Assertions.*;
@@ -30,7 +29,7 @@ class CrewMemberServiceImplTest extends ServiceTest {
 	void create_success() {
 
 		//given
-		Crew crew = createCrew(savedStore, RECRUITING);
+		Crew crew = createCrew(savedStore);
 
 		crewRepository.save(crew);
 

--- a/src/test/java/com/prgrms/mukvengers/domain/proposal/api/ProposalControllerTest.java
+++ b/src/test/java/com/prgrms/mukvengers/domain/proposal/api/ProposalControllerTest.java
@@ -21,7 +21,6 @@ import org.junit.jupiter.api.Test;
 import com.epages.restdocs.apispec.Schema;
 import com.prgrms.mukvengers.base.ControllerTest;
 import com.prgrms.mukvengers.domain.crew.model.Crew;
-import com.prgrms.mukvengers.domain.crew.model.vo.CrewStatus;
 import com.prgrms.mukvengers.domain.proposal.dto.request.CreateProposalRequest;
 import com.prgrms.mukvengers.domain.proposal.model.Proposal;
 import com.prgrms.mukvengers.domain.user.model.User;
@@ -40,7 +39,7 @@ class ProposalControllerTest extends ControllerTest {
 		// given
 		User leader = userRepository.save(createUser("1232456789"));
 
-		Crew crew = crewRepository.save(createCrew(savedStore, CrewStatus.RECRUITING));
+		Crew crew = crewRepository.save(createCrew(savedStore));
 
 		CreateProposalRequest proposalRequest = ProposalObjectProvider.createProposalRequest(leader.getId());
 
@@ -62,7 +61,7 @@ class ProposalControllerTest extends ControllerTest {
 						.requestFields(
 							fieldWithPath("leaderId").type(NUMBER).description("해당 밥모임의 리더 아이디"),
 							fieldWithPath("content").type(STRING).description("신청서 내용")
-							)
+						)
 						.responseHeaders(
 							headerWithName("Location").description("조회해볼 수 있는 요청 주소"))
 						.build()
@@ -77,7 +76,7 @@ class ProposalControllerTest extends ControllerTest {
 		User user = createUser("1232456789");
 		userRepository.save(user);
 
-		Crew crew = createCrew(savedStore, CrewStatus.RECRUITING);
+		Crew crew = createCrew(savedStore);
 		crewRepository.save(crew);
 
 		List<Proposal> proposals = ProposalObjectProvider.createProposals(user, savedUser.getId(), crew.getId());
@@ -125,7 +124,7 @@ class ProposalControllerTest extends ControllerTest {
 		User user = createUser("1232456789");
 		userRepository.save(user);
 
-		Crew crew = createCrew(savedStore, CrewStatus.RECRUITING);
+		Crew crew = createCrew(savedStore);
 		crewRepository.save(crew);
 
 		List<Proposal> proposals = ProposalObjectProvider.createProposals(savedUser, user.getId(), crew.getId());

--- a/src/test/java/com/prgrms/mukvengers/domain/proposal/api/ProposalControllerTest.java
+++ b/src/test/java/com/prgrms/mukvengers/domain/proposal/api/ProposalControllerTest.java
@@ -78,7 +78,7 @@ class ProposalControllerTest extends ControllerTest {
 		User user = createUser("1232456789");
 		userRepository.save(user);
 
-		Crew crew = createCrew(savedStore, CrewStatus.RECRUITING);
+		Crew crew = createCrew(savedStore);
 		crewRepository.save(crew);
 
 		Proposal proposal = ProposalObjectProvider.createProposal(user, savedUser.getId(), crew.getId());

--- a/src/test/java/com/prgrms/mukvengers/domain/proposal/service/ProposalServiceImplTest.java
+++ b/src/test/java/com/prgrms/mukvengers/domain/proposal/service/ProposalServiceImplTest.java
@@ -161,7 +161,7 @@ class ProposalServiceImplTest extends ServiceTest {
 		User user = createUser("1232456789");
 		userRepository.save(user);
 
-		Crew crew = createCrew(savedStore, CrewStatus.RECRUITING);
+		Crew crew = createCrew(savedStore);
 		crewRepository.save(crew);
 
 		Proposal proposal = ProposalObjectProvider.createProposal(user, savedUser.getId(), crew.getId());
@@ -176,7 +176,7 @@ class ProposalServiceImplTest extends ServiceTest {
 			.hasFieldOrPropertyWithValue("crewId", crew.getId())
 			.hasFieldOrPropertyWithValue("content", proposal.getContent())
 			.hasFieldOrPropertyWithValue("status", proposal.getStatus());
-		
+
 		assertThat(response.user())
 			.hasFieldOrPropertyWithValue("id", user.getId())
 			.hasFieldOrPropertyWithValue("nickname", user.getNickname())

--- a/src/test/java/com/prgrms/mukvengers/domain/proposal/service/ProposalServiceImplTest.java
+++ b/src/test/java/com/prgrms/mukvengers/domain/proposal/service/ProposalServiceImplTest.java
@@ -14,7 +14,6 @@ import org.junit.jupiter.api.Test;
 
 import com.prgrms.mukvengers.base.ServiceTest;
 import com.prgrms.mukvengers.domain.crew.model.Crew;
-import com.prgrms.mukvengers.domain.crew.model.vo.CrewStatus;
 import com.prgrms.mukvengers.domain.crewmember.model.CrewMember;
 import com.prgrms.mukvengers.domain.crewmember.model.vo.CrewMemberRole;
 import com.prgrms.mukvengers.domain.proposal.dto.request.CreateProposalRequest;
@@ -35,7 +34,7 @@ class ProposalServiceImplTest extends ServiceTest {
 		User createUser = createUser("12121212");
 		User leader = userRepository.save(createUser);
 
-		Crew createCrew = createCrew(savedStore, CrewStatus.RECRUITING);
+		Crew createCrew = createCrew(savedStore);
 		Crew crew = crewRepository.save(createCrew);
 
 		CreateProposalRequest proposalRequest = ProposalObjectProvider.createProposalRequest(leader.getId());
@@ -61,13 +60,15 @@ class ProposalServiceImplTest extends ServiceTest {
 		User createUser = createUser("12121212");
 		User leader = userRepository.save(createUser);
 
-		Crew createCrew = createCrew(savedStore, CrewStatus.RECRUITING);
+		Crew createCrew = createCrew(savedStore);
 		Crew crew = crewRepository.save(createCrew);
 
-		CrewMember createCrewMember = CrewMemberObjectProvider.createCrewMember(leader.getId(), crew, CrewMemberRole.LEADER);
+		CrewMember createCrewMember = CrewMemberObjectProvider.createCrewMember(leader.getId(), crew,
+			CrewMemberRole.LEADER);
 		crewMemberRepository.save(createCrewMember);
 
-		List<CrewMember> crewMembers = CrewMemberObjectProvider.createCrewMembers(savedUserId, crew, CrewMemberRole.MEMBER,
+		List<CrewMember> crewMembers = CrewMemberObjectProvider.createCrewMembers(savedUserId, crew,
+			CrewMemberRole.MEMBER,
 			crew.getCapacity());
 
 		crewMemberRepository.saveAll(crewMembers);
@@ -88,10 +89,11 @@ class ProposalServiceImplTest extends ServiceTest {
 	void createProposal_fail_blockedUser() {
 
 		//given
-		Crew createCrew = createCrew(savedStore, CrewStatus.RECRUITING);
+		Crew createCrew = createCrew(savedStore);
 		Crew crew = crewRepository.save(createCrew);
 
-		CrewMember createCrewMember = CrewMemberObjectProvider.createCrewMember(savedUserId, crew, CrewMemberRole.BLOCKED);
+		CrewMember createCrewMember = CrewMemberObjectProvider.createCrewMember(savedUserId, crew,
+			CrewMemberRole.BLOCKED);
 		crewMemberRepository.save(createCrewMember);
 
 		CreateProposalRequest proposalRequest = ProposalObjectProvider.createProposalRequest(savedUserId);
@@ -110,10 +112,11 @@ class ProposalServiceImplTest extends ServiceTest {
 	void createProposal_fail_LeaderUser() {
 
 		//given
-		Crew createCrew = createCrew(savedStore, CrewStatus.RECRUITING);
+		Crew createCrew = createCrew(savedStore);
 		Crew crew = crewRepository.save(createCrew);
 
-		CrewMember createCrewMember = CrewMemberObjectProvider.createCrewMember(savedUserId, crew, CrewMemberRole.LEADER);
+		CrewMember createCrewMember = CrewMemberObjectProvider.createCrewMember(savedUserId, crew,
+			CrewMemberRole.LEADER);
 		crewMemberRepository.save(createCrewMember);
 
 		CreateProposalRequest proposalRequest = ProposalObjectProvider.createProposalRequest(savedUserId);
@@ -132,10 +135,11 @@ class ProposalServiceImplTest extends ServiceTest {
 	void createProposal_fail_DuplicatedUser() {
 
 		//given
-		Crew createCrew = createCrew(savedStore, CrewStatus.RECRUITING);
+		Crew createCrew = createCrew(savedStore);
 		Crew crew = crewRepository.save(createCrew);
 
-		CrewMember createCrewMember = CrewMemberObjectProvider.createCrewMember(savedUserId, crew, CrewMemberRole.MEMBER);
+		CrewMember createCrewMember = CrewMemberObjectProvider.createCrewMember(savedUserId, crew,
+			CrewMemberRole.MEMBER);
 		crewMemberRepository.save(createCrewMember);
 
 		CreateProposalRequest proposalRequest = ProposalObjectProvider.createProposalRequest(savedUserId);
@@ -157,7 +161,7 @@ class ProposalServiceImplTest extends ServiceTest {
 		User user = createUser("1232456789");
 		userRepository.save(user);
 
-		Crew crew = createCrew(savedStore, CrewStatus.RECRUITING);
+		Crew crew = createCrew(savedStore);
 		crewRepository.save(crew);
 
 		List<Proposal> proposals = createProposals(user, savedUser.getId(), crew.getId());
@@ -178,7 +182,7 @@ class ProposalServiceImplTest extends ServiceTest {
 		User user = createUser("1232456789");
 		userRepository.save(user);
 
-		Crew crew = createCrew(savedStore, CrewStatus.RECRUITING);
+		Crew crew = createCrew(savedStore);
 		crewRepository.save(crew);
 
 		List<Proposal> proposals = createProposals(savedUser, user.getId(), crew.getId());

--- a/src/test/java/com/prgrms/mukvengers/domain/review/api/ReviewControllerTest.java
+++ b/src/test/java/com/prgrms/mukvengers/domain/review/api/ReviewControllerTest.java
@@ -23,7 +23,6 @@ import org.springframework.util.MultiValueMap;
 import com.epages.restdocs.apispec.Schema;
 import com.prgrms.mukvengers.base.ControllerTest;
 import com.prgrms.mukvengers.domain.crew.model.Crew;
-import com.prgrms.mukvengers.domain.crew.model.vo.CrewStatus;
 import com.prgrms.mukvengers.domain.crewmember.model.CrewMember;
 import com.prgrms.mukvengers.domain.crewmember.model.vo.CrewMemberRole;
 import com.prgrms.mukvengers.domain.review.dto.request.CreateLeaderReviewRequest;
@@ -50,7 +49,7 @@ class ReviewControllerTest extends ControllerTest {
 	void setCrew() {
 		reviewer = savedUser;
 		reviewee = userRepository.save(UserObjectProvider.createUser("kakao_1212"));
-		crew = crewRepository.save(createCrew(savedStore, CrewStatus.RECRUITING));
+		crew = crewRepository.save(createCrew(savedStore));
 	}
 
 	@Test

--- a/src/test/java/com/prgrms/mukvengers/domain/review/repository/ReviewRepositoryTest.java
+++ b/src/test/java/com/prgrms/mukvengers/domain/review/repository/ReviewRepositoryTest.java
@@ -10,7 +10,6 @@ import org.springframework.data.domain.Pageable;
 
 import com.prgrms.mukvengers.base.RepositoryTest;
 import com.prgrms.mukvengers.domain.crew.model.Crew;
-import com.prgrms.mukvengers.domain.crew.model.vo.CrewStatus;
 import com.prgrms.mukvengers.domain.review.model.Review;
 import com.prgrms.mukvengers.domain.user.model.User;
 import com.prgrms.mukvengers.utils.CrewObjectProvider;
@@ -27,7 +26,7 @@ class ReviewRepositoryTest extends RepositoryTest {
 		User createUser = UserObjectProvider.createUser("kakao_1234");
 		User reviewer = userRepository.save(createUser);
 
-		Crew createCrew = CrewObjectProvider.createCrew(savedStore, CrewStatus.RECRUITING);
+		Crew createCrew = CrewObjectProvider.createCrew(savedStore);
 		Crew crew = crewRepository.save(createCrew);
 
 		Integer page = 0;
@@ -54,7 +53,7 @@ class ReviewRepositoryTest extends RepositoryTest {
 		User createUser = UserObjectProvider.createUser("kakao_1234");
 		User reviewee = userRepository.save(createUser);
 
-		Crew createCrew = CrewObjectProvider.createCrew(savedStore, CrewStatus.RECRUITING);
+		Crew createCrew = CrewObjectProvider.createCrew(savedStore);
 		Crew crew = crewRepository.save(createCrew);
 
 		Integer page = 0;

--- a/src/test/java/com/prgrms/mukvengers/domain/review/repository/ReviewRepositoryTest.java
+++ b/src/test/java/com/prgrms/mukvengers/domain/review/repository/ReviewRepositoryTest.java
@@ -82,7 +82,7 @@ class ReviewRepositoryTest extends RepositoryTest {
 		User createUser = UserObjectProvider.createUser("kakao_1");
 		User reviewer = userRepository.save(createUser);
 
-		Crew createCrew = CrewObjectProvider.createCrew(savedStore, CrewStatus.RECRUITING);
+		Crew createCrew = CrewObjectProvider.createCrew(savedStore);
 		Crew crew = crewRepository.save(createCrew);
 
 		Review review = ReviewObjectProvider.createLeaderReview(reviewer, savedUser, crew);

--- a/src/test/java/com/prgrms/mukvengers/domain/review/service/ReviewServiceImplTest.java
+++ b/src/test/java/com/prgrms/mukvengers/domain/review/service/ReviewServiceImplTest.java
@@ -1,6 +1,5 @@
 package com.prgrms.mukvengers.domain.review.service;
 
-import static com.prgrms.mukvengers.domain.crew.model.vo.CrewStatus.*;
 import static com.prgrms.mukvengers.utils.CrewObjectProvider.*;
 import static com.prgrms.mukvengers.utils.ReviewObjectProvider.*;
 import static com.prgrms.mukvengers.utils.UserObjectProvider.*;
@@ -19,7 +18,6 @@ import com.prgrms.mukvengers.base.ServiceTest;
 import com.prgrms.mukvengers.domain.crew.model.Crew;
 import com.prgrms.mukvengers.domain.crewmember.model.CrewMember;
 import com.prgrms.mukvengers.domain.crewmember.model.vo.CrewMemberRole;
-import com.prgrms.mukvengers.domain.crewmember.repository.CrewMemberRepository;
 import com.prgrms.mukvengers.domain.review.dto.request.CreateLeaderReviewRequest;
 import com.prgrms.mukvengers.domain.review.dto.request.CreateMemberReviewRequest;
 import com.prgrms.mukvengers.domain.review.dto.response.ReviewResponse;
@@ -38,7 +36,7 @@ class ReviewServiceImplTest extends ServiceTest {
 	void setReview() {
 		reviewer = savedUser;
 		reviewee = userRepository.save(createUser("kakao_1212"));
-		crew = crewRepository.save(createCrew(savedStore, RECRUITING));
+		crew = crewRepository.save(createCrew(savedStore));
 	}
 
 	@Test

--- a/src/test/java/com/prgrms/mukvengers/utils/CrewObjectProvider.java
+++ b/src/test/java/com/prgrms/mukvengers/utils/CrewObjectProvider.java
@@ -32,7 +32,7 @@ public class CrewObjectProvider {
 	private static final Point LOCATION = GF.createPoint(
 		new Coordinate(Double.parseDouble(LONGITUDE), Double.parseDouble(LATITUDE)));
 
-	public static Crew createCrew(Store store, CrewStatus status) {
+	public static Crew createCrew(Store store) {
 		return Crew.builder()
 			.store(store)
 			.name(NAME)
@@ -46,7 +46,7 @@ public class CrewObjectProvider {
 
 	public static List<Crew> createCrews(Store store) {
 		return IntStream.range(0, 20)
-			.mapToObj(i -> createCrew(store, i % 2 == 0 ? STATUS_CLOSE : STATUS_RECRUITING))
+			.mapToObj(i -> createCrew(store))
 			.collect(Collectors.toList());
 	}
 


### PR DESCRIPTION
### 🌱 작업 사항 
- 모임 상태를 모집 종료 -> 식사 완료로 변경합니다. 

### ❓ 리뷰 포인트
- 모집 중 -> 모집 종료 api와 코드가 매우 비슷합니다. 
- 하나의 api로 처리하고 메서드 안에서 분기로 나누는것을 고민하고 있습니다.
- 팀원분들은 어떻게 생각하시나요? 더 좋은 방법이 있을까요?

### 🦄 관련 이슈
- resolves #135 


