### PR TITLE
[#143] 신청서(Proposal) 수락/거절 상태값 변경 API 수정 및 기타 수정

### DIFF
--- a/src/main/java/com/prgrms/mukvengers/domain/proposal/api/ProposalController.java
+++ b/src/main/java/com/prgrms/mukvengers/domain/proposal/api/ProposalController.java
@@ -110,21 +110,21 @@ public class ProposalController {
 
 	/**
 	 * <pre>
-	 *     방장으로부터 수락/거절 응답을 받으면 그에 맞는 응답을 한다.
+	 *     방장은 신청서를 수락/거절 응답할 수 있다.
 	 * </pre>
 	 * @param proposalId 신청서 아이디
 	 * @param proposalRequest 신청서 수정 dto
 	 * @param user 유저 정보
 	 * @return
 	 */
-	@PatchMapping(value = "/proposals/{proposalId}", consumes = APPLICATION_JSON_VALUE, produces = APPLICATION_JSON_VALUE)
-	public ResponseEntity<ApiResponse<Void>> approve
+	@PatchMapping(value = "/proposals/{proposalId}", consumes = APPLICATION_JSON_VALUE)
+	public ResponseEntity<ApiResponse<Void>> changeProposalStatus
 	(
 		@PathVariable Long proposalId,
 		@RequestBody @Valid UpdateProposalRequest proposalRequest,
 		@AuthenticationPrincipal JwtAuthentication user
 	) {
-		 proposalService.approve(proposalRequest, user.id(), proposalId);
+		 proposalService.updateProposalStatus(proposalRequest, user.id(), proposalId);
 
 		return ResponseEntity.ok().build();
 	}

--- a/src/main/java/com/prgrms/mukvengers/domain/proposal/service/ProposalService.java
+++ b/src/main/java/com/prgrms/mukvengers/domain/proposal/service/ProposalService.java
@@ -16,5 +16,5 @@ public interface ProposalService {
 
 	ProposalResponses getProposalsByMemberId(Long userId);
 
-	void approve(UpdateProposalRequest proposalRequest, Long userId, Long proposalId);
+	void updateProposalStatus(UpdateProposalRequest proposalRequest, Long userId, Long proposalId);
 }

--- a/src/main/java/com/prgrms/mukvengers/domain/proposal/service/ProposalServiceImpl.java
+++ b/src/main/java/com/prgrms/mukvengers/domain/proposal/service/ProposalServiceImpl.java
@@ -115,7 +115,7 @@ public class ProposalServiceImpl implements ProposalService {
 
 	@Override
 	@Transactional
-	public void approve(UpdateProposalRequest proposalRequest, Long userId, Long proposalId) {
+	public void updateProposalStatus(UpdateProposalRequest proposalRequest, Long userId, Long proposalId) {
 
 		if (!userRepository.existsById(userId)) {
 			throw new UserNotFoundException(userId);
@@ -138,9 +138,11 @@ public class ProposalServiceImpl implements ProposalService {
 
 		proposal.changeProposalStatus(proposalStatus);
 
-		if (!proposal.isApprove(proposalStatus)) return;
+		if (!proposal.isApprove(proposalStatus))
+			return;
 
-		CrewMember createCrewMember = crewMemberMapper.toCrewMember(crew, proposal.getUser().getId(), CrewMemberRole.MEMBER);
+		CrewMember createCrewMember = crewMemberMapper.toCrewMember(crew, proposal.getUser().getId(),
+			CrewMemberRole.MEMBER);
 
 		CrewMember crewMember = crewMemberRepository.save(createCrewMember);
 

--- a/src/main/java/com/prgrms/mukvengers/domain/proposal/service/ProposalServiceImpl.java
+++ b/src/main/java/com/prgrms/mukvengers/domain/proposal/service/ProposalServiceImpl.java
@@ -131,16 +131,16 @@ public class ProposalServiceImpl implements ProposalService {
 
 		ProposalStatus proposalStatus = ProposalStatus.of(status);
 
-		registerCrewMember(proposal, crew, userId, proposalStatus);
+		registerCrewMember(proposal, crew, proposalStatus);
 	}
 
-	private void registerCrewMember(Proposal proposal, Crew crew, Long userId, ProposalStatus proposalStatus) {
+	private void registerCrewMember(Proposal proposal, Crew crew, ProposalStatus proposalStatus) {
 
 		proposal.changeProposalStatus(proposalStatus);
 
 		if (!proposal.isApprove(proposalStatus)) return;
 
-		CrewMember createCrewMember = crewMemberMapper.toCrewMember(crew, userId, CrewMemberRole.MEMBER);
+		CrewMember createCrewMember = crewMemberMapper.toCrewMember(crew, proposal.getUser().getId(), CrewMemberRole.MEMBER);
 
 		CrewMember crewMember = crewMemberRepository.save(createCrewMember);
 

--- a/src/main/java/com/prgrms/mukvengers/global/exception/ErrorCode.java
+++ b/src/main/java/com/prgrms/mukvengers/global/exception/ErrorCode.java
@@ -39,12 +39,11 @@ public enum ErrorCode {
 	REVIEW_NOT_FOUND(HttpStatus.NOT_FOUND, "R001", "존재하지 않는 리뷰입니다."),
 	REVIEW_NO_ACCESS(HttpStatus.UNAUTHORIZED, "R002", "해당 리뷰를 볼 수 있는 접근 권한이 없습니다."),
 
+
 	// Proposal
 	PROPOSAL_NOT_FOUND(HttpStatus.NOT_FOUND, "P001", "존재하지 않는 신청서입니다."),
-	PROPOSAL_BLOCKED_USER(HttpStatus.FORBIDDEN, "P002", "강퇴된 밥모임에는 신청서를 작성할 수 없습니다."),
-	REFUSED_PROPOSAL(HttpStatus.NOT_FOUND, "P003", "작성하신 신청서가 거절되었습니다."),
-	INVALID_PROPOSAL_STATUS(HttpStatus.NOT_FOUND, "P004", "올바르지 않은 신청서 응답 상태입니다."),
-	
+	INVALID_PROPOSAL_STATUS(HttpStatus.NOT_FOUND, "P002", "올바르지 않은 신청서 응답 상태입니다."),
+
 	// Auth
 	INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "A001", "유효하지 않은 토큰입니다."),
 	EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, "A002", "만료된 토큰입니다."),

--- a/src/test/java/com/prgrms/mukvengers/domain/proposal/api/ProposalControllerTest.java
+++ b/src/test/java/com/prgrms/mukvengers/domain/proposal/api/ProposalControllerTest.java
@@ -176,20 +176,12 @@ class ProposalControllerTest extends ControllerTest {
 	@DisplayName("[성공] 방장이 신청서를 승인하는 경우 신청서의 상태값이 'APPROVE' 로 변경되며 밥모임원에 저장된다.")
 	void update_proposalStatus_approve_success() throws Exception {
 
-		User createUser = createUser("1232456789");
-		User user = userRepository.save(createUser);
-
 		Crew creatCrew = createCrew(savedStore);
-		Crew creatCrew = createCrew(savedStore, CrewStatus.RECRUITING);
 		Crew crew = crewRepository.save(creatCrew);
 
-		CrewMember crewMemberOfLeader = CrewMemberObjectProvider.createCrewMember(user.getId(), crew,
-			CrewMemberRole.LEADER);
 		CrewMember crewMemberOfLeader = CrewMemberObjectProvider.createCrewMember(savedUserId, crew, CrewMemberRole.LEADER);
 		CrewMember leader = crewMemberRepository.save(crewMemberOfLeader);
 
-		CrewMember crewMemberOfMember = CrewMemberObjectProvider.createCrewMember(user.getId(), crew,
-			CrewMemberRole.MEMBER);
 		User createUser = createUser("1232456789");
 		User user = userRepository.save(createUser);
 

--- a/src/test/java/com/prgrms/mukvengers/domain/proposal/api/ProposalControllerTest.java
+++ b/src/test/java/com/prgrms/mukvengers/domain/proposal/api/ProposalControllerTest.java
@@ -180,14 +180,20 @@ class ProposalControllerTest extends ControllerTest {
 		User user = userRepository.save(createUser);
 
 		Crew creatCrew = createCrew(savedStore);
+		Crew creatCrew = createCrew(savedStore, CrewStatus.RECRUITING);
 		Crew crew = crewRepository.save(creatCrew);
 
 		CrewMember crewMemberOfLeader = CrewMemberObjectProvider.createCrewMember(user.getId(), crew,
 			CrewMemberRole.LEADER);
+		CrewMember crewMemberOfLeader = CrewMemberObjectProvider.createCrewMember(savedUserId, crew, CrewMemberRole.LEADER);
 		CrewMember leader = crewMemberRepository.save(crewMemberOfLeader);
 
 		CrewMember crewMemberOfMember = CrewMemberObjectProvider.createCrewMember(user.getId(), crew,
 			CrewMemberRole.MEMBER);
+		User createUser = createUser("1232456789");
+		User user = userRepository.save(createUser);
+
+		CrewMember crewMemberOfMember = CrewMemberObjectProvider.createCrewMember(user.getId(), crew, CrewMemberRole.MEMBER);
 		crewMemberRepository.save(crewMemberOfMember);
 
 		Proposal createProposal = ProposalObjectProvider.createProposal(user, leader.getId(), crew.getId());

--- a/src/test/java/com/prgrms/mukvengers/domain/proposal/service/ProposalServiceImplTest.java
+++ b/src/test/java/com/prgrms/mukvengers/domain/proposal/service/ProposalServiceImplTest.java
@@ -1,5 +1,6 @@
 package com.prgrms.mukvengers.domain.proposal.service;
 
+import static com.prgrms.mukvengers.domain.proposal.model.vo.ProposalStatus.*;
 import static com.prgrms.mukvengers.domain.proposal.service.ProposalServiceImpl.*;
 import static com.prgrms.mukvengers.utils.CrewObjectProvider.*;
 import static com.prgrms.mukvengers.utils.ProposalObjectProvider.*;
@@ -169,24 +170,26 @@ class ProposalServiceImplTest extends ServiceTest {
 		Crew creatCrew = createCrew(savedStore);
 		Crew crew = crewRepository.save(creatCrew);
 
-		CrewMember crewMemberOfLeader = CrewMemberObjectProvider.createCrewMember(savedUserId, crew,
-			CrewMemberRole.LEADER);
+		CrewMember crewMemberOfLeader = CrewMemberObjectProvider.createCrewMember(savedUserId, crew, CrewMemberRole.LEADER);
 		CrewMember leader = crewMemberRepository.save(crewMemberOfLeader);
 
-		Proposal createProposal = ProposalObjectProvider.createProposal(user, leader.getId(), crew.getId());
+		User createUser = createUser("1232456789");
+		User user = userRepository.save(createUser);
+
+		Proposal createProposal = ProposalObjectProvider.createProposal(user, leader.getUserId(), crew.getId());
 		Proposal proposal = proposalRepository.save(createProposal);
 
 		UpdateProposalRequest proposalRequest = new UpdateProposalRequest(inputProposalStatus);
 
 		// when
-		proposalService.approve(proposalRequest, user.getId(), proposal.getId());
-		Optional<CrewMember> saveCrewMember = crewMemberRepository.findCrewMemberByCrewIdAndUserId(
+		proposalService.approve(proposalRequest, leader.getUserId(), proposal.getId());
+		Optional<CrewMember> result = crewMemberRepository.findCrewMemberByCrewIdAndUserId(
 			crew.getId(), user.getId());
 
 		// then
-		assertThat(proposal.getStatus()).isEqualTo(ProposalStatus.APPROVE);
-		assertThat(saveCrewMember).isPresent();
-		assertThat(saveCrewMember.get().getUserId()).isEqualTo(user.getId());
+		assertThat(proposal.getStatus()).isEqualTo(APPROVE);
+		assertThat(result).isPresent();
+		assertThat(result.get().getUserId()).isEqualTo(user.getId());
 	}
 
 	@Test
@@ -201,17 +204,19 @@ class ProposalServiceImplTest extends ServiceTest {
 		Crew creatCrew = createCrew(savedStore);
 		Crew crew = crewRepository.save(creatCrew);
 
-		CrewMember crewMemberOfLeader = CrewMemberObjectProvider.createCrewMember(savedUserId, crew,
-			CrewMemberRole.LEADER);
+		CrewMember crewMemberOfLeader = CrewMemberObjectProvider.createCrewMember(savedUserId, crew, CrewMemberRole.LEADER);
 		CrewMember leader = crewMemberRepository.save(crewMemberOfLeader);
 
-		Proposal createProposal = ProposalObjectProvider.createProposal(user, leader.getId(), crew.getId());
+		User createUser = createUser("1232456789");
+		User user = userRepository.save(createUser);
+
+		Proposal createProposal = ProposalObjectProvider.createProposal(user, leader.getUserId(), crew.getId());
 		Proposal proposal = proposalRepository.save(createProposal);
 
 		UpdateProposalRequest proposalRequest = new UpdateProposalRequest(inputProposalStatus);
 
 		// when
-		proposalService.approve(proposalRequest, user.getId(), proposal.getId());
+		proposalService.approve(proposalRequest, leader.getUserId(), proposal.getId());
 		Optional<CrewMember> saveCrewMember = crewMemberRepository.findCrewMemberByCrewIdAndUserId(
 			crew.getId(), user.getId());
 
@@ -236,6 +241,9 @@ class ProposalServiceImplTest extends ServiceTest {
 			CrewMemberRole.LEADER);
 		CrewMember leader = crewMemberRepository.save(crewMemberOfLeader);
 
+		User createUser = createUser("1232456789");
+		User user = userRepository.save(createUser);
+
 		Proposal createProposal = ProposalObjectProvider.createProposal(user, leader.getId(), crew.getId());
 		Proposal proposal = proposalRepository.save(createProposal);
 
@@ -244,7 +252,7 @@ class ProposalServiceImplTest extends ServiceTest {
 		// when & then
 		assertThatThrownBy
 			(
-				() -> proposalService.approve(proposalRequest, user.getId(), proposal.getId())
+				() -> proposalService.approve(proposalRequest, leader.getUserId(), proposal.getId())
 			)
 			.isInstanceOf(InvalidProposalStatusException.class);
 	}

--- a/src/test/java/com/prgrms/mukvengers/domain/proposal/service/ProposalServiceImplTest.java
+++ b/src/test/java/com/prgrms/mukvengers/domain/proposal/service/ProposalServiceImplTest.java
@@ -182,7 +182,7 @@ class ProposalServiceImplTest extends ServiceTest {
 		UpdateProposalRequest proposalRequest = new UpdateProposalRequest(inputProposalStatus);
 
 		// when
-		proposalService.approve(proposalRequest, leader.getUserId(), proposal.getId());
+		proposalService.updateProposalStatus(proposalRequest, leader.getUserId(), proposal.getId());
 		Optional<CrewMember> result = crewMemberRepository.findCrewMemberByCrewIdAndUserId(
 			crew.getId(), user.getId());
 
@@ -216,7 +216,7 @@ class ProposalServiceImplTest extends ServiceTest {
 		UpdateProposalRequest proposalRequest = new UpdateProposalRequest(inputProposalStatus);
 
 		// when
-		proposalService.approve(proposalRequest, leader.getUserId(), proposal.getId());
+		proposalService.updateProposalStatus(proposalRequest, leader.getUserId(), proposal.getId());
 		Optional<CrewMember> saveCrewMember = crewMemberRepository.findCrewMemberByCrewIdAndUserId(
 			crew.getId(), user.getId());
 
@@ -252,7 +252,7 @@ class ProposalServiceImplTest extends ServiceTest {
 		// when & then
 		assertThatThrownBy
 			(
-				() -> proposalService.approve(proposalRequest, leader.getUserId(), proposal.getId())
+				() -> proposalService.updateProposalStatus(proposalRequest, leader.getUserId(), proposal.getId())
 			)
 			.isInstanceOf(InvalidProposalStatusException.class);
 	}

--- a/src/test/java/com/prgrms/mukvengers/domain/proposal/service/ProposalServiceImplTest.java
+++ b/src/test/java/com/prgrms/mukvengers/domain/proposal/service/ProposalServiceImplTest.java
@@ -164,9 +164,6 @@ class ProposalServiceImplTest extends ServiceTest {
 
 		//given
 		String inputProposalStatus = "승인";
-		User createUser = createUser("1232456789");
-		User user = userRepository.save(createUser);
-
 		Crew creatCrew = createCrew(savedStore);
 		Crew crew = crewRepository.save(creatCrew);
 
@@ -198,8 +195,6 @@ class ProposalServiceImplTest extends ServiceTest {
 
 		//given
 		String inputProposalStatus = "거절";
-		User createUser = createUser("1232456789");
-		User user = userRepository.save(createUser);
 
 		Crew creatCrew = createCrew(savedStore);
 		Crew crew = crewRepository.save(creatCrew);
@@ -231,8 +226,6 @@ class ProposalServiceImplTest extends ServiceTest {
 
 		//given
 		String inputProposalStatus = "모름";
-		User createUser = createUser("1232456789");
-		User user = userRepository.save(createUser);
 
 		Crew creatCrew = createCrew(savedStore);
 		Crew crew = crewRepository.save(creatCrew);


### PR DESCRIPTION
<!-- 제목은 `[#이슈번호] 제목` 으로 작성한다. ex) [#8] 결제 기능 -->

### 🌱 작업 사항 
- update 메서드명 updateProposalStatus로 변경하였습니다.
- 수락/거절하는 상태 변경 API userId -> leaderId로 변경하였습니다.
- 사용하지 않는 error 코드 삭제하였습니다.

### ❓ 리뷰 포인트
- 빠진 부분 있는지 확인해주세요!
### 🦄 관련 이슈
resolves #143 


