### PR TITLE
[#148] Swagger UI에서 docExpansion 설정 'none'으로 변경

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -96,7 +96,6 @@ dependencies {
     implementation group: 'ca.pjer', name: 'logback-awslogs-appender', version: '1.6.0'
     // AWS
     implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
-
     //Slack Notification
     implementation "net.gpedro.integrations.slack:slack-webhook:1.4.0"
 }
@@ -141,7 +140,7 @@ tasks.withType(BootJar).configureEach {
     dependsOn 'copySwaggerUI'
     doLast {
         println('---replace \'full\' text to \'none\' ----')
-        def indexFile = file("${project.buildDir}/swagger-ui-sample/index.html")
+        def indexFile = file("${project.buildDir}/resources/main/static/docs/index.html")
 
         def contents = indexFile.getText("UTF-8")
         def newFileContents = contents.replace('full', 'none')


### PR DESCRIPTION
### 🌱 작업 사항 
- 프론트에서 Swagger 확인시에 API창이 열려 있는게 불편하다고 닫혀있는 상태로 변경을 요청하셔서 일단은 Gradle에서 설정하는 방법을 몰라서 하드 코딩으로 생성후 글자를 변경하는 방식으로 요구 사항을 반영했습니다.
- [refactor(Build): Swagger UI에서 docExpansion 설정 'none'으로](https://github.com/prgrms-web-devcourse/Team-Kkini-Mukvengers-BE/commit/bf8a61cc9547bb917ec29ab0d515f244e67a5339)
- [refactor(Build): Swagger UI에서 docExpansion 설정 'none'으로 변경](https://github.com/prgrms-web-devcourse/Team-Kkini-Mukvengers-BE/commit/8e106eb95649b2bcb0a8877ba150f3b36cd56018)
<img width="1351" alt="스크린샷 2023-03-11 오후 2 58 41" src="https://user-images.githubusercontent.com/99165624/224467868-bb0770f5-8840-4769-9781-66da8ae78dc1.png">


### 🦄 관련 이슈
- #148 





