### PR TITLE
[#148] Swagger UI의 docExpansion 설정을 jar 파일에도 적용

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -128,6 +128,16 @@ tasks.register('copySwaggerUI', Copy) {
 
     from("${generateSwaggerUISampleTask.outputDir}")
     into("${project.buildDir}/resources/main/static/docs/")
+
+    doLast {
+        println('---replace \'full\' text to \'none\' ----')
+        def indexFile = file("${project.buildDir}/resources/main/static/docs/index.html")
+
+        def contents = indexFile.getText("UTF-8")
+        def newFileContents = contents.replace('full', 'none')
+        indexFile.write(newFileContents)
+        println('---- replace end.-----')
+    }
 }
 
 task copyDocument(type: Copy) {
@@ -138,15 +148,6 @@ task copyDocument(type: Copy) {
 
 tasks.withType(BootJar).configureEach {
     dependsOn 'copySwaggerUI'
-    doLast {
-        println('---replace \'full\' text to \'none\' ----')
-        def indexFile = file("${project.buildDir}/resources/main/static/docs/index.html")
-
-        def contents = indexFile.getText("UTF-8")
-        def newFileContents = contents.replace('full', 'none')
-        indexFile.write(newFileContents)
-        println('---- replace end.-----')
-    }
 }
 
 


### PR DESCRIPTION
### 🌱 작업 사항 
- 이전 PR(#149)에서는 bootJar에만 동작하여 jar파일에는 적용이 안되었던 것 같아서 copySwaggerUI Task 후 진행할 수 있도록 수정했습니다
### ❓ 리뷰 포인트
### 🦄 관련 이슈
- #148 



