### PR TITLE
[#165] 밥모임의 채팅내역을 조회하는 api 추가

### DIFF
--- a/src/main/java/com/prgrms/mukvengers/domain/chat/api/ChatController.java
+++ b/src/main/java/com/prgrms/mukvengers/domain/chat/api/ChatController.java
@@ -1,5 +1,8 @@
 package com.prgrms.mukvengers.domain.chat.api;
 
+import static org.springframework.http.MediaType.*;
+
+import java.util.List;
 import java.util.Map;
 
 import org.springframework.data.domain.Pageable;
@@ -17,6 +20,7 @@ import org.springframework.web.bind.annotation.ResponseBody;
 
 import com.prgrms.mukvengers.domain.chat.dto.request.ChatRequest;
 import com.prgrms.mukvengers.domain.chat.dto.response.ChatResponse;
+import com.prgrms.mukvengers.domain.chat.dto.response.ChatResponses;
 import com.prgrms.mukvengers.domain.chat.dto.response.ChatsInCrew;
 import com.prgrms.mukvengers.domain.chat.service.ChatService;
 import com.prgrms.mukvengers.global.common.dto.ApiResponse;
@@ -32,7 +36,7 @@ public class ChatController {
 	private final ChatService chatService;
 
 	@ResponseBody
-	@GetMapping("/api/v1/crews/{crewId}/chats")
+	@GetMapping(value = "/api/v2/crews/{crewId}/chats", produces = APPLICATION_JSON_VALUE)
 	public ResponseEntity<ApiResponse<ChatsInCrew>> getChattingList(
 		@PathVariable(name = "crewId") Long crewId,
 		@PageableDefault(sort = "createdAt") Pageable pageable) {
@@ -40,6 +44,18 @@ public class ChatController {
 		ChatsInCrew result = chatService.getByCrewId(crewId, pageable);
 
 		return ResponseEntity.ok(new ApiResponse<>(result));
+	}
+
+	@ResponseBody
+	@GetMapping(value = "/api/v1/crews/{crewId}/chats", produces = APPLICATION_JSON_VALUE)
+	public ResponseEntity<ApiResponse<ChatResponses>> getChattingList(
+		@PathVariable(name = "crewId") Long crewId) {
+
+		List<ChatResponse> result = chatService.getAllByCrewId(crewId);
+
+		ChatResponses chatResponses = new ChatResponses(result);
+
+		return ResponseEntity.ok(new ApiResponse<>(chatResponses));
 	}
 
 	@MessageMapping("/chat.sendMessage/{crewId}")

--- a/src/main/java/com/prgrms/mukvengers/domain/chat/dto/response/ChatResponse.java
+++ b/src/main/java/com/prgrms/mukvengers/domain/chat/dto/response/ChatResponse.java
@@ -8,6 +8,7 @@ import lombok.Builder;
 
 @Builder
 public record ChatResponse(
+	Long id,
 	Long userId,
 	String username,
 	String profileImgUrl,

--- a/src/main/java/com/prgrms/mukvengers/domain/chat/dto/response/ChatResponses.java
+++ b/src/main/java/com/prgrms/mukvengers/domain/chat/dto/response/ChatResponses.java
@@ -1,0 +1,8 @@
+package com.prgrms.mukvengers.domain.chat.dto.response;
+
+import java.util.List;
+
+public record ChatResponses(
+	List<ChatResponse> chats
+) {
+}

--- a/src/main/java/com/prgrms/mukvengers/domain/chat/repository/ChatRepository.java
+++ b/src/main/java/com/prgrms/mukvengers/domain/chat/repository/ChatRepository.java
@@ -1,5 +1,7 @@
 package com.prgrms.mukvengers.domain.chat.repository;
 
+import java.util.List;
+
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -15,10 +17,20 @@ public interface ChatRepository extends JpaRepository<Chat, Long> {
 	@Query("""
 			SELECT 
 			new com.prgrms.mukvengers.domain.chat.dto.response.ChatResponse
-			(u.id, u.nickname, u.profileImgUrl, c.type, c.createdAt, c.content) 
+			(c.id, u.id, u.nickname, u.profileImgUrl, c.type, c.createdAt, c.content) 
 			FROM Chat c 
 			JOIN User u ON u.id = c.userId 
 			WHERE c.crewId = :crewId
 		""")
 	Page<ChatResponse> findByCrewId(@Param("crewId") Long crewId, Pageable pageable);
+
+	@Query("""
+			SELECT 
+			new com.prgrms.mukvengers.domain.chat.dto.response.ChatResponse
+			(c.id, u.id, u.nickname, u.profileImgUrl, c.type, c.createdAt, c.content) 
+			FROM Chat c 
+			JOIN User u ON u.id = c.userId 
+			WHERE c.crewId = :crewId
+		""")
+	List<ChatResponse> findAllByCrewId(@Param("crewId") Long crewId);
 }

--- a/src/main/java/com/prgrms/mukvengers/domain/chat/service/ChatService.java
+++ b/src/main/java/com/prgrms/mukvengers/domain/chat/service/ChatService.java
@@ -1,5 +1,6 @@
 package com.prgrms.mukvengers.domain.chat.service;
 
+import java.util.List;
 import java.util.Map;
 
 import org.springframework.data.domain.Pageable;
@@ -12,4 +13,6 @@ public interface ChatService {
 	ChatResponse save(ChatRequest chatRequest, Long crewId, Map<String, Object> headers);
 
 	ChatsInCrew getByCrewId(Long crewId, Pageable pageable);
+
+	List<ChatResponse> getAllByCrewId(Long crewId);
 }

--- a/src/main/java/com/prgrms/mukvengers/domain/chat/service/ChatServiceImpl.java
+++ b/src/main/java/com/prgrms/mukvengers/domain/chat/service/ChatServiceImpl.java
@@ -1,5 +1,6 @@
 package com.prgrms.mukvengers.domain.chat.service;
 
+import java.util.List;
 import java.util.Map;
 
 import org.springframework.data.domain.Page;
@@ -39,6 +40,11 @@ public class ChatServiceImpl implements ChatService {
 	public ChatsInCrew getByCrewId(Long crewId, Pageable pageable) {
 		Page<ChatResponse> result = chatRepository.findByCrewId(crewId, pageable);
 		return new ChatsInCrew(result);
+	}
+
+	@Override
+	public List<ChatResponse> getAllByCrewId(Long crewId) {
+		return chatRepository.findAllByCrewId(crewId);
 	}
 
 	private ChatResponse toChatResponse(Chat chat, Map<String, Object> header) {

--- a/src/test/java/com/prgrms/mukvengers/base/ServiceTest.java
+++ b/src/test/java/com/prgrms/mukvengers/base/ServiceTest.java
@@ -10,6 +10,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.prgrms.mukvengers.domain.chat.repository.ChatRepository;
+import com.prgrms.mukvengers.domain.chat.service.ChatService;
 import com.prgrms.mukvengers.domain.crew.repository.CrewRepository;
 import com.prgrms.mukvengers.domain.crew.service.CrewService;
 import com.prgrms.mukvengers.domain.crewmember.repository.CrewMemberRepository;
@@ -63,6 +64,9 @@ public abstract class ServiceTest {
 
 	@Autowired
 	protected ChatRepository chatRepository;
+
+	@Autowired
+	protected ChatService chatService;
 
 	protected GeometryFactory gf = new GeometryFactory();
 

--- a/src/test/java/com/prgrms/mukvengers/domain/chat/service/ChatServiceImplTest.java
+++ b/src/test/java/com/prgrms/mukvengers/domain/chat/service/ChatServiceImplTest.java
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
+import org.springframework.test.annotation.Rollback;
 
 import com.prgrms.mukvengers.base.ServiceTest;
 import com.prgrms.mukvengers.domain.chat.dto.response.ChatResponse;
@@ -23,7 +24,7 @@ class ChatServiceImplTest extends ServiceTest {
 
 	@BeforeEach
 	void setup() {
-		userId = 100L;
+		userId = 1L;
 		crewId = 100L;
 	}
 
@@ -53,5 +54,18 @@ class ChatServiceImplTest extends ServiceTest {
 
 		//then
 		assertEquals(5, result.getSize());
+	}
+
+	@Test
+	@Rollback(value = false)
+	void getAllByCrewId() {
+		//given
+		List<Chat> chatList = ChatObjectProvider.getChatList(crewId, userId);
+		chatRepository.saveAll(chatList);
+
+		//when
+		List<ChatResponse> result = chatRepository.findAllByCrewId(crewId);
+
+		assertEquals(chatList.size(), result.size());
 	}
 }

--- a/src/test/java/com/prgrms/mukvengers/domain/chat/service/ChatServiceImplTest.java
+++ b/src/test/java/com/prgrms/mukvengers/domain/chat/service/ChatServiceImplTest.java
@@ -9,7 +9,6 @@ import org.junit.jupiter.api.Test;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
-import org.springframework.test.annotation.Rollback;
 
 import com.prgrms.mukvengers.base.ServiceTest;
 import com.prgrms.mukvengers.domain.chat.dto.response.ChatResponse;
@@ -54,18 +53,5 @@ class ChatServiceImplTest extends ServiceTest {
 
 		//then
 		assertEquals(5, result.getSize());
-	}
-
-	@Test
-	@Rollback(value = false)
-	void getAllByCrewId() {
-		//given
-		List<Chat> chatList = ChatObjectProvider.getChatList(crewId, userId);
-		chatRepository.saveAll(chatList);
-
-		//when
-		List<ChatResponse> result = chatRepository.findAllByCrewId(crewId);
-
-		assertEquals(chatList.size(), result.size());
 	}
 }


### PR DESCRIPTION
### 🌱 작업 사항 
- crewId를 이용해 밥모임의 채팅 정보를 가져오는 API를 추가했습니다.
- 기존에 존재하는 API는 Pageable을 Request로 받아서 처리합니다.  시연할 때 편의를 위해 전체 조회하는 API를 요청하셔서 생성하게 되었습니다.
 
### ❓ 리뷰 포인트
- 기존 Pageable을 받는 API는 v2로 변경해두었습니다.

### 🦄 관련 이슈
- resolves #165 


